### PR TITLE
Add log events for removed reactions

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1,4 +1,4 @@
-import { Client, GatewayIntentBits, Collection, Events } from 'discord.js';
+import { Client, GatewayIntentBits, Collection, Events, Partials } from 'discord.js';
 import guildAuditLogEntryCreateHandler from '@/events/guildAuditLogEntryCreate';
 import guildMemberRemoveHandler from '@/events/guildMemberRemove';
 import guildMemberUpdateHandler from '@/events/guildMemberUpdate';
@@ -6,21 +6,28 @@ import interactionCreateHandler from '@/events/interactionCreate';
 import messageCreateHandler from '@/events/messageCreate';
 import messageDeleteHandler from '@/events/messageDelete';
 import messageUpdateHandler from '@/events/messageUpdate';
+import reactionRemoveHandler from '@/events/reactionRemove';
 import readyHandler from '@/events/ready';
 import config from '@/config.json';
-import type { ClientCommand } from '@/types';
+import type { ClientContextMenu, ClientCommand } from '@/types';
 
 export const client = new Client({
+	partials: [
+		Partials.Reaction,
+		Partials.Message
+	],
 	intents: [
 		GatewayIntentBits.Guilds,
 		GatewayIntentBits.GuildMessages,
 		GatewayIntentBits.MessageContent,
 		GatewayIntentBits.GuildMembers,
-		GatewayIntentBits.GuildModeration
+		GatewayIntentBits.GuildModeration,
+		GatewayIntentBits.GuildMessageReactions,
 	]
 });
 
 client.commands = new Collection<string, ClientCommand>();
+client.contextMenus = new Collection<string, ClientContextMenu>();
 
 client.on(Events.ClientReady, readyHandler);
 client.on(Events.GuildMemberRemove, guildMemberRemoveHandler);
@@ -30,5 +37,6 @@ client.on(Events.MessageCreate, messageCreateHandler);
 client.on(Events.MessageDelete, messageDeleteHandler);
 client.on(Events.MessageUpdate, messageUpdateHandler);
 client.on(Events.GuildAuditLogEntryCreate, guildAuditLogEntryCreateHandler);
+client.on(Events.MessageReactionRemove, reactionRemoveHandler);
 
 client.login(config.bot_token);

--- a/src/context-menus/messages/message-log.ts
+++ b/src/context-menus/messages/message-log.ts
@@ -1,0 +1,51 @@
+import { MessageAuditRelationship } from '@/models/messageAuditRelationship';
+import { getChannelFromSettings } from '@/util';
+import { ApplicationCommandType, ChannelType, ContextMenuCommandBuilder } from 'discord.js';
+import type { MessageContextMenuCommandInteraction } from 'discord.js';
+
+async function messageLogMenuHandler(interaction: MessageContextMenuCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const messageAuditRelationships = await MessageAuditRelationship.findAll({
+		where: {
+			message_id: interaction.targetMessage.id
+		}
+	});
+
+	if (messageAuditRelationships.length > 0) {
+		const auditLogChannel = await getChannelFromSettings(interaction.guild!, 'channels.event-logs');
+		if (!auditLogChannel || auditLogChannel.type !== ChannelType.GuildText) {
+			console.error('no log channel specified');
+			return;
+		}
+
+		let message = `Log events for message ${interaction.targetMessage.url}`;
+		message += '\n> ';
+		message += interaction.targetMessage.content.substring(0, 1024);
+		if (interaction.targetMessage.content.length > 1024) {
+			message += '…';
+		}
+		message += '\n\n';
+		for (const relationship of messageAuditRelationships) {
+			const logEvent = await auditLogChannel.messages.fetch(relationship.log_event_id);
+			message += '- ';
+			message += logEvent.url;
+			message += '\n';
+		}
+
+		await interaction.followUp({ content: message });
+	} else {
+		await interaction.followUp({ content: 'No audit logs found for this message' });
+	}
+}
+
+const messageLogContextMenu = new ContextMenuCommandBuilder()
+	.setName('Message events')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.Message);
+
+export default {
+	name: 'Message events',
+	handler: messageLogMenuHandler,
+	deploy: messageLogContextMenu.toJSON()
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,13 +1,16 @@
 import buttonHandler from '@/handlers/button-handler';
 import commandHandler from '@/handlers/command-handler';
+import messageContextMenuHandler from '@/handlers/context-menu-handler';
 import type { Interaction } from 'discord.js'; 
 
 export default async function interactionCreateHandler(interaction: Interaction): Promise<void> {
 	try {
-		if (interaction.isCommand()) {
+		if (interaction.isChatInputCommand()) {
 			await commandHandler(interaction);
 		} else if (interaction.isButton()) {
 			await buttonHandler(interaction);
+		} else if (interaction.isContextMenuCommand()) {
+			await messageContextMenuHandler(interaction);
 		}
 	} catch (error: any) {
 		if (!interaction.isCommand()) {

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -4,8 +4,6 @@ import type { Message, PartialMessage } from 'discord.js';
 
 export default async function messageDeleteHandler(message: Message | PartialMessage): Promise<void> {
 	if (message.partial) {
-		// * This should never happen as we don't opt into partial structures
-		// * but we need this to be here to convince the compiler that the rest is safe
 		return;
 	}
 

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -1,12 +1,15 @@
 import { BaseGuildTextChannel, EmbedBuilder } from 'discord.js';
 import { sendEventLogMessage } from '@/util';
 import type { Message, PartialMessage } from 'discord.js';
+import { MessageAuditRelationship } from '@/models/messageAuditRelationship';
 
 export default async function messageUpdateHandler(oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage): Promise<void> {
-	if (oldMessage.partial || newMessage.partial) {
-		// * This should never happen as we don't opt into partial structures
-		// * but we need this to be here to convince the compiler that the rest is safe
-		return;
+	if (oldMessage.partial) {
+		oldMessage = await oldMessage.fetch();
+	}
+
+	if (newMessage.partial) {
+		newMessage = await newMessage.fetch();
 	}
 
 	if (newMessage.author.bot) {
@@ -64,6 +67,14 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 			iconURL: guild.iconURL()!
 		});
 
-		await sendEventLogMessage(guild, newMessage.channelId, eventLogEmbed);
+		const audit = await sendEventLogMessage(guild, newMessage.channelId, eventLogEmbed);
+		if (!audit) {
+			return;
+		}
+
+		await MessageAuditRelationship.create({ 
+			message_id: newMessage.id,
+			log_event_id: audit.id
+		});
 	}
 }

--- a/src/events/reactionRemove.ts
+++ b/src/events/reactionRemove.ts
@@ -72,6 +72,8 @@ export default async function reactionRemoveHandler(reaction: MessageReaction | 
 }
 
 async function createThread(audit: Message): Promise<ThreadChannel> {
+	// * This must be wrapped in a try to prevent a race condition which
+	// * occurs when many reactions are removed from the same message in quick succession
 	try {
 		return await audit.startThread({ name: 'Event detail thread', reason: 'Thread for adding reaction removal events' });
 	} catch {

--- a/src/events/reactionRemove.ts
+++ b/src/events/reactionRemove.ts
@@ -72,7 +72,11 @@ export default async function reactionRemoveHandler(reaction: MessageReaction | 
 }
 
 async function createThread(audit: Message): Promise<ThreadChannel> {
-	return audit.startThread({ name: 'Reaction removal thread', reason: 'Thread for reaction removal' });
+	try {
+		return await audit.startThread({ name: 'Event detail thread', reason: 'Thread for adding reaction removal events' });
+	} catch {
+		return audit.thread!;
+	}
 }
 
 function createEmbed(reaction: MessageReaction, message: Message): EmbedBuilder {

--- a/src/events/reactionRemove.ts
+++ b/src/events/reactionRemove.ts
@@ -1,0 +1,125 @@
+import { BaseGuildTextChannel, ChannelType, EmbedBuilder, GuildEmoji } from 'discord.js';
+import { MessageAuditRelationship } from '@/models/messageAuditRelationship';
+import { getChannelFromSettings, sendEventLogMessage } from '@/util';
+import type { Message, MessageReaction, PartialMessageReaction, PartialUser, ThreadChannel, User } from 'discord.js';
+
+export default async function reactionRemoveHandler(reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser): Promise<void> {
+	if (reaction.partial === true) {
+		reaction = await reaction.fetch();
+	}
+
+	if (reaction.message.partial === true) {
+		reaction.message = await reaction.message.fetch();
+	}
+
+	const messageAuditRelationship = await MessageAuditRelationship.findOne({
+		where: {
+			message_id: reaction.message.id
+		},
+		order: [['created', 'desc']]
+	});
+
+	let message = `${reaction.emoji.name} removed by <@${user.id}>`;
+	if (reaction.emoji.imageURL()) {
+		if (reaction.emoji instanceof GuildEmoji) {
+			message = `<:${reaction.emoji.identifier}> removed by <@${user.id}>`;
+		} else {
+			message = `[:${reaction.emoji.name}:](${reaction.emoji.imageURL()}?size=44&quality=lossless) removed by <@${user.id}>`;
+		}
+	}
+
+	if (!messageAuditRelationship) {
+		const embed = createEmbed(reaction, reaction.message);
+
+		const audit = await sendEventLogMessage(reaction.message.guild!, reaction.message.channelId, embed);
+		if (!audit) {
+			return;
+		}
+
+		await MessageAuditRelationship.create({ 
+			message_id: reaction.message.id,
+			log_event_id: audit.id
+		});
+
+		const thread = await createThread(audit);
+		await thread.send({
+			content: message,
+			allowedMentions: {
+				parse: []
+			}
+		});
+		await thread.setArchived(true);
+	} else {
+		const auditLogChannel = await getChannelFromSettings(reaction.message.guild!, 'channels.event-logs');
+		if (!auditLogChannel || auditLogChannel.type !== ChannelType.GuildText) {
+			console.error('no log channel specified');
+			return;
+		}
+
+		const auditMessage = await auditLogChannel.messages.fetch(messageAuditRelationship.log_event_id);
+		if (!auditMessage) {
+			console.log('no log event found for message');
+			return;
+		}
+
+		const thread = auditMessage.thread ?? await createThread(auditMessage);
+		await thread.send({ 
+			content: message,
+			allowedMentions: { parse: [] }
+		});
+		await thread.setArchived(true);
+	}
+}
+
+async function createThread(audit: Message): Promise<ThreadChannel> {
+	return audit.startThread({ name: 'Reaction removal thread', reason: 'Thread for reaction removal' });
+}
+
+function createEmbed(reaction: MessageReaction, message: Message): EmbedBuilder {
+	let channelName = 'No channel name found';
+	if (reaction.message.channel instanceof BaseGuildTextChannel) {
+		channelName = reaction.message.channel.name;
+	}
+
+	const embed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Reactions Removed_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields([
+			{
+				name: 'User',
+				value: `<@${reaction.message.author!.id}>`
+			},
+			{
+				name: 'User ID',
+				value: reaction.message.author!.id
+			},
+			{
+				name: 'Channel Tag',
+				value: `<#${reaction.message.channelId}>`
+			},
+			{
+				name: 'Channel Name',
+				value: channelName
+			},
+			{
+				name: 'Message',
+				value: reaction.message.url
+			}
+		])
+		.setFooter({
+			text: 'Pretendo Network',
+			iconURL: reaction.message.guild!.iconURL()!
+		});
+
+	if (message.content.length > 0) {
+		embed.addFields([
+			{
+				name: 'Message contents',
+				value: message.content
+			}
+		]);
+	}
+
+	return embed;
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -5,16 +5,16 @@ import banCommand from '@/commands/ban';
 import kickCommand from '@/commands/kick';
 import settingsCommand from '@/commands/settings';
 import warnCommand from '@/commands/warn';
+import messageLogContextMenu from '@/context-menus/messages/message-log';
 import { checkMatchmakingThreads } from '@/matchmaking-threads';
 import { loadModel } from '@/check-nsfw';
 import type { Database } from 'sqlite3';
-import type { Client, Collection } from 'discord.js';
-import type { ClientCommand } from '@/types';
+import type { Client } from 'discord.js';
 import config from '@/config.json';
 
 export default async function readyHandler(client: Client): Promise<void> {
 	console.log('Registering global commands');
-	loadBotHandlersCollection('commands', client.commands);
+	loadBotHandlersCollection('commands', client);
 
 	console.log('Establishing DB connection');
 	await sequelize.sync(config.sequelize);
@@ -40,9 +40,11 @@ export default async function readyHandler(client: Client): Promise<void> {
 	await checkMatchmakingThreads();
 }
 
-function loadBotHandlersCollection(name: string, collection: Collection<string, ClientCommand>): void {
-	collection.set(banCommand.name, banCommand);
-	collection.set(kickCommand.name, kickCommand);
-	collection.set(settingsCommand.name, settingsCommand);
-	collection.set(warnCommand.name, warnCommand);
+function loadBotHandlersCollection(name: string, client: Client): void {
+	client.commands.set(banCommand.name, banCommand);
+	client.commands.set(kickCommand.name, kickCommand);
+	client.commands.set(settingsCommand.name, settingsCommand);
+	client.commands.set(warnCommand.name, warnCommand);
+
+	client.contextMenus.set(messageLogContextMenu.name, messageLogContextMenu);
 }

--- a/src/handlers/command-handler.ts
+++ b/src/handlers/command-handler.ts
@@ -6,11 +6,11 @@ export default async function commandHandler(interaction: CommandInteraction): P
 	const commands = interaction.client.commands;
 	const command = commands.get(commandName);
 
-	// do nothing if no command
+	// * Do nothing if no command
 	if (!command) {
 		throw new Error(`Missing command handler for \`${commandName}\``);
 	}
 
-	// run the command
+	// * Run the command
 	await command.handler(interaction);
 }

--- a/src/handlers/context-menu-handler.ts
+++ b/src/handlers/context-menu-handler.ts
@@ -1,0 +1,16 @@
+import type { ContextMenuCommandInteraction } from 'discord.js';
+
+export default async function messageContextMenuHandler(interaction: ContextMenuCommandInteraction): Promise<void> {
+	const { commandName } = interaction;
+
+	const contextMenus = interaction.client.contextMenus;
+	const contextMenu = contextMenus.get(commandName);
+
+	// do nothing if no context menu
+	if (!contextMenu) {
+		throw new Error(`Missing command handler for \`${commandName}\``);
+	}
+
+	// run the context menu
+	await contextMenu.handler(interaction);
+}

--- a/src/handlers/context-menu-handler.ts
+++ b/src/handlers/context-menu-handler.ts
@@ -6,11 +6,11 @@ export default async function messageContextMenuHandler(interaction: ContextMenu
 	const contextMenus = interaction.client.contextMenus;
 	const contextMenu = contextMenus.get(commandName);
 
-	// do nothing if no context menu
+	// * Do nothing if no context menu
 	if (!contextMenu) {
 		throw new Error(`Missing command handler for \`${commandName}\``);
 	}
 
-	// run the context menu
+	// * Run the context menu
 	await contextMenu.handler(interaction);
 }

--- a/src/models/messageAuditRelationship.ts
+++ b/src/models/messageAuditRelationship.ts
@@ -1,0 +1,39 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '@/sequelize-instance';
+import type { CreationOptional, InferAttributes, InferCreationAttributes } from 'sequelize';
+
+export class MessageAuditRelationship extends Model<InferAttributes<MessageAuditRelationship>, InferCreationAttributes<MessageAuditRelationship>> {
+	declare id: CreationOptional<number>;
+	declare message_id: string;
+	declare log_event_id: string;
+	declare created: CreationOptional<Date>;
+}
+
+MessageAuditRelationship.init({
+	id: {
+		type: DataTypes.INTEGER,
+		autoIncrement: true,
+		primaryKey: true
+	},
+	message_id: {
+		type: DataTypes.STRING,
+	},
+	log_event_id: {
+		type: DataTypes.STRING,
+		unique: true
+	},
+	created: {
+		type: DataTypes.DATE,
+		defaultValue: DataTypes.NOW
+	}
+}, {
+	sequelize,
+	tableName: 'message-audit-relationships',
+	timestamps: false,
+	indexes: [
+		{
+			name: 'mar-created_idx',
+			fields: ['created']
+		}
+	]
+});

--- a/src/setup-guild.ts
+++ b/src/setup-guild.ts
@@ -22,11 +22,15 @@ export async function setupGuild(guild: Guild): Promise<void> {
 
 async function deployCommands(guild: Guild): Promise<void> {
 
-	const deploy = guild.client.commands.map((command) => {
+	const commands = guild.client.commands.map((command) => {
 		return command.deploy;
 	});
 
+	const contextMenus = guild.client.contextMenus.map((contextMenu) => {
+		return contextMenu.deploy;
+	});
+
 	await rest.put(Routes.applicationGuildCommands(guild.members.me!.id, guild.id), {
-		body: deploy,
+		body: [...commands, ...contextMenus],
 	});
 }

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -1,7 +1,9 @@
 import type { Collection } from 'discord.js';
+import type { ClientCommand, ClientContextMenu } from '.';
 
 declare module 'discord.js' {
 	export interface Client {
-		commands: Collection<string, any>
+		commands: Collection<string, ClientCommand>
+		contextMenus: Collection<string, ClientContextMenu>
 	}
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,3 +3,9 @@ export interface ClientCommand {
 	handler: any,
 	deploy: object
 }
+
+export interface ClientContextMenu {
+	name: string,
+	handler: any,
+	deploy: object
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { getDB, getDBList } from '@/db';
 import { ChannelType } from 'discord.js';
-import type { Channel, EmbedBuilder, Guild, Role } from 'discord.js';
+import type { Channel, EmbedBuilder, Guild, Role, Message } from 'discord.js';
 
 const ordinalRules = new Intl.PluralRules('en', {
 	type: 'ordinal'
@@ -19,19 +19,19 @@ export function ordinal(number: number): string {
 	return (number + suffix);
 }
 
-export async function sendEventLogMessage(guild: Guild, originId: string | null, embed: EmbedBuilder): Promise<void> {
+export async function sendEventLogMessage(guild: Guild, originId: string | null, embed: EmbedBuilder, content?: string): Promise<Message | null> {
 	const blacklistedIds = getDBList('channels.event-logs.blacklist');
 	if (originId && blacklistedIds.includes(originId)) {
-		return;
+		return null;
 	}
 
 	const logChannel = await getChannelFromSettings(guild, 'channels.event-logs');
 	if (!logChannel || logChannel.type !== ChannelType.GuildText) {
 		console.log('Missing log channel!');
-		return;
+		return null;
 	}
 
-	await logChannel.send({ embeds: [embed] });
+	return logChannel.send({ content, embeds: [embed] });
 }
 
 export async function getChannelFromSettings(guild: Guild, channelName: string): Promise<Channel | null> {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #19 

### Changes:

#### Reaction removal threads
When a reaction is removed from a message, we find the latest event log related to the message and add a message to the "Reaction removal thread" for that message. 

As we currently only add events to the log when messages are updated, if there is no existing event for a message a "Reactions removed" log will be added and used as the basis for the initial thread.

Doing this means that:
- We have a log of what the message content was at the time the reaction was removed
- Each reaction removal is timestamped
- As each "Reaction removal thread" is archived upon creation and after each new message, it never appears in the channel list and never contributes towards our server thread limit

##### "Reactions removed" log example with the "Reaction removal thread" shown
![image](https://github.com/user-attachments/assets/42304315-6bb2-40fb-84d5-dc85515b0bbd)

##### "Reaction removal thread"
This shows the three different kinds of reactions:
1. Regular emoji reaction
2. Custom emoji reaction from the server that Chubby is in
3. Custom emoji reaction from a different server, these are displayed differently as Chubby cannot reproduce the emoji directly without being a member of the server the emoji is from
![image](https://github.com/user-attachments/assets/eeaf511b-8d90-4b2e-bc9e-7bf271398d7a)

#### Message events context menu
Especially now we're adding extra things which can cause an event log for a particular message, it can be tough finding the relevant event log for a message. To assist with this, I've added a context menu command for messages which will display links to all of the log events for a particular message.

![image](https://github.com/user-attachments/assets/10834453-d844-4983-88d2-21eeed8ee128)

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.