### PR TITLE
Auto slow mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,7 @@
 	],
 	"rules": {
 		"@typescript-eslint/no-non-null-assertion": "off",
-		"@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+		"@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
 		"@typescript-eslint/no-extra-semi": "error",
 		"@typescript-eslint/keyword-spacing": "error",
 		"require-atomic-updates": "warn",

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -109,7 +109,7 @@ async function setStageHandler(interaction: ChatInputCommandInteraction): Promis
 		]);
 	}
 
-	if (slowMode.stages) {
+	if (slowMode.stages && slowMode.stages.length > 0) {
 		const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
 			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
 		}).join('\n');
@@ -183,7 +183,7 @@ async function unsetStageHandler(interaction: ChatInputCommandInteraction): Prom
 			iconURL: interaction.guild!.iconURL()!
 		});
 
-	if (slowMode.stages) {
+	if (slowMode.stages && slowMode.stages.length > 0) {
 		const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
 			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
 		}).join('\n');
@@ -258,7 +258,7 @@ async function enableAutoSlowModeHandler(interaction: ChatInputCommandInteractio
 			iconURL: interaction.guild!.iconURL()!
 		});
 
-	if (slowMode.stages) {
+	if (slowMode.stages && slowMode.stages.length > 0) {
 		const stagesMessage = slowMode.stages.map(stage => {
 			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
 		}).join('\n');
@@ -440,7 +440,7 @@ async function slowModeStatsHandler(interaction: ChatInputCommandInteraction): P
 			}
 		]);
 
-		if (slowMode.stages) {
+		if (slowMode.stages && slowMode.stages.length > 0) {
 			const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
 				return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
 			}).join('\n');

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -1,0 +1,579 @@
+import { SlowMode, SlowModeStage } from '@/models/slow-mode';
+import handleSlowMode from '@/slow-mode';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { sendEventLogMessage } from '@/util';
+import { ChannelType, EmbedBuilder, type ChatInputCommandInteraction } from 'discord.js';
+
+async function slowModeHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	switch (interaction.options.getSubcommandGroup()) {
+		case 'stage': {
+			switch (interaction.options.getSubcommand()) {
+				case 'set':
+					return setStageHandler(interaction);
+				case 'unset':
+					return unsetStageHandler(interaction);
+			}
+			break;
+		}
+		case 'enable': {
+			switch (interaction.options.getSubcommand()) {
+				case 'auto':
+					return enableAutoSlowModeHandler(interaction);
+				case 'static':
+					return enableStaticSlowModeHandler(interaction);
+			}
+			break;
+		}
+		case null: {
+			switch (interaction.options.getSubcommand()) {
+				case 'disable':
+					return disableSlowModeHandler(interaction);
+				case 'stats':
+					return slowModeStatsHandler(interaction);
+			}
+		}
+	}
+
+	throw new Error('Unknown slow mode command');
+}
+
+async function setStageHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel') ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	const slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		},
+		include: 'stages'
+	});
+
+	if (!slowMode) {
+		throw new Error(`No slow mode set for <#${channel.id}>`);
+	}
+
+	const threshold = interaction.options.getNumber('threshold', true);
+	const limit = interaction.options.getNumber('limit', true);
+
+	let oldLimit: number | null = null;
+	let stage = slowMode.stages?.find(stage => stage.threshold === threshold);
+	if (stage) {
+		oldLimit = stage.limit;
+		stage.limit = interaction.options.getNumber('limit', true);
+		await stage.save();
+	} else {
+		stage = await SlowModeStage.create({
+			threshold,
+			limit
+		});
+		await slowMode.addStage(stage);
+		await slowMode.reload({ include: 'stages' });
+	}
+
+	const auditLogEmbed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Auto Slow-Mode Threshold Set_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields(
+			{
+				name: 'User',
+				value: `<@${interaction.user.id}>`
+			},
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			},
+			{
+				name: 'New Threshold',
+				value: `Limit of 1 message every ${limit} seconds above ${threshold} messages per minute`
+			}
+		).setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+
+	if (oldLimit) {
+		auditLogEmbed.addFields([
+			{
+				name: 'Old Threshold',
+				value: `Limit of 1 message every ${oldLimit} seconds above ${threshold} messages per minute`
+			}
+		]);
+	}
+
+	if (slowMode.stages) {
+		const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
+			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
+		}).join('\n');
+	
+		auditLogEmbed.addFields([
+			{
+				name: 'Configured stages',
+				value: stagesMessage
+			}
+		]);
+	}
+		
+	await sendEventLogMessage(interaction.guild!, channel.id, auditLogEmbed);
+
+	await interaction.followUp({ content: `Set a limit of 1 message every ${limit} seconds above ${threshold} messages per minute on <#${channel.id}>` });
+}
+
+async function unsetStageHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel') ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	const slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		},
+		include: 'stages'
+	});
+
+	if (!slowMode) {
+		throw new Error(`No slow mode set for <#${channel.id}>`);
+	}
+
+	const threshold = interaction.options.getNumber('threshold', true);
+
+	const stage = slowMode.stages?.find(stage => stage.threshold === threshold);
+	if (!stage) {
+		throw new Error(`No stage set at ${threshold} messages per minute`);
+	}
+
+	const oldLimit = stage.limit;
+	await slowMode.removeStage(stage);
+	await slowMode.reload({ include: 'stages' });
+
+	const auditLogEmbed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Auto Slow-Mode Threshold Unset_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields(
+			{
+				name: 'User',
+				value: `<@${interaction.user.id}>`
+			},
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			},
+			{
+				name: 'Old Threshold',
+				value: `Limit of 1 message every ${oldLimit} seconds above ${threshold} messages per minute`
+			}
+		).setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+
+	if (slowMode.stages) {
+		const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
+			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
+		}).join('\n');
+	
+		auditLogEmbed.addFields([
+			{
+				name: 'Configured stages',
+				value: stagesMessage
+			}
+		]);
+	}
+		
+	await sendEventLogMessage(interaction.guild!, channel.id, auditLogEmbed);
+
+	await interaction.followUp({ content: `Unset the limit at ${threshold} messages per minute on <#${channel.id}>` });
+}
+
+async function enableAutoSlowModeHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel') ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	let slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		},
+		include: 'stages'
+	});
+
+	if (slowMode) {
+		slowMode.enabled = true;
+	} else {
+		slowMode = await SlowMode.create({
+			channel_id: channel.id,
+			window: 60000,
+			enabled: true
+		});
+	}
+
+	const window = interaction.options.getNumber('window');
+	if (window) {
+		slowMode.window = window;
+	}
+
+	await slowMode.save();
+
+	// * This returns a Promise but is specifically not awaited as it should spawn its own loop
+	handleSlowMode(interaction.guild!, slowMode);
+
+	const auditLogEmbed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Auto Slow-Mode Enabled_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields(
+			{
+				name: 'User',
+				value: `<@${interaction.user.id}>`
+			},
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			}
+		).setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+
+	if (slowMode.stages) {
+		const stagesMessage = slowMode.stages.map(stage => {
+			return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
+		}).join('\n');
+	
+		auditLogEmbed.addFields([
+			{
+				name: 'Configured stages',
+				value: stagesMessage
+			}
+		]);
+	}
+
+	await sendEventLogMessage(interaction.guild!, channel.id, auditLogEmbed);
+
+	await interaction.followUp({ content: `Auto slow mode enabled for <#${channel.id}>` });
+}
+
+async function enableStaticSlowModeHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]) ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	const slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		},
+		include: 'stages'
+	});
+
+	if (slowMode) {
+		slowMode.enabled = false;
+		await slowMode.save();
+	}
+
+	const limit = interaction.options.getNumber('limit', true);
+	channel.setRateLimitPerUser(limit);
+
+	const auditLogEmbed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Static Slow-Mode Enabled_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields(
+			{
+				name: 'User',
+				value: `<@${interaction.user.id}>`
+			},
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			},
+			{
+				name: 'Limit',
+				value: `1 message every ${limit} seconds`
+			}
+		).setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+
+	await sendEventLogMessage(interaction.guild!, channel.id, auditLogEmbed);
+
+	await interaction.followUp({ content: `Static slow mode enabled for <#${channel.id}>` });
+}
+
+async function disableSlowModeHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]) ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	const slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		}
+	});
+
+	if ((!slowMode || !slowMode.enabled) && channel.rateLimitPerUser === 0) {
+		throw new Error(`Slow mode for <#${channel.id}> is already disabled`);
+	}
+
+	if (slowMode && slowMode.enabled === true) {
+		slowMode.enabled = false;
+		await slowMode.save();
+	}
+
+	await channel.setRateLimitPerUser(0);
+
+	const auditLogEmbed = new EmbedBuilder()
+		.setColor(0xC0C0C0)
+		.setTitle('Event Type: _Slow-Mode Disabled_')
+		.setDescription('――――――――――――――――――――――――――――――――――')
+		.setFields(
+			{
+				name: 'User',
+				value: `<@${interaction.user.id}>`
+			},
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			}
+		).setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+
+	await sendEventLogMessage(interaction.guild!, channel.id, auditLogEmbed);
+
+	await interaction.followUp({ content: `Slow mode disabled for <#${channel.id}>` });
+}
+
+async function slowModeStatsHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	await interaction.deferReply({ ephemeral: true });
+
+	const channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]) ?? interaction.channel;
+	if (!channel) {
+		throw new Error('No channel given');
+	}
+
+	if (channel.type !== ChannelType.GuildText) {
+		throw new Error('Slow mode only applies to text channels');
+	}
+
+	const slowMode = await SlowMode.findOne({
+		where: {
+			channel_id: channel.id
+		},
+		include: 'stages'
+	});
+
+	if (channel.rateLimitPerUser === 0) {
+		if (!slowMode || !slowMode.enabled) {
+			throw new Error(`No slow mode set for <#${channel.id}>`);
+		}
+	}
+
+	const embed = new EmbedBuilder()
+		.setTitle('Slow mode stats')
+		.setFields([
+			{
+				name: 'Channel',
+				value: `<#${channel.id}>`
+			},
+		])
+		.setFooter({
+			text: 'Pretendo Network',
+			iconURL: interaction.guild!.iconURL()!
+		});
+	
+	if (slowMode && slowMode.enabled) {
+		embed.addFields([
+			{
+				name: 'Participating Users',
+				value: slowMode.users.toString()
+			},
+			{
+				name: 'Current Rate',
+				value: slowMode.rate.toString()
+			},
+			{
+				name: 'Current Limit',
+				value: `1 message every ${slowMode.limit} seconds`
+			},
+			{
+				name: 'Window',
+				value: `${(slowMode.window / 1000).toString()} seconds`
+			}
+		]);
+
+		if (slowMode.stages) {
+			const stagesMessage = slowMode.stages.sort((a, b) => a.threshold - b.threshold).map(stage => {
+				return `1 message every ${stage.limit}s above ${stage.threshold} messages per minute`;
+			}).join('\n');
+		
+			embed.addFields([
+				{
+					name: 'Configured stages',
+					value: stagesMessage
+				}
+			]);
+		}
+	} else {
+		embed.addFields([
+			{
+				name: 'Current limit',
+				value: `1 message every ${channel.rateLimitPerUser} seconds`
+			}
+		]);
+	}
+
+	await interaction.followUp({ embeds: [embed] });
+}
+
+const command = new SlashCommandBuilder()
+	.setDefaultMemberPermissions('0')
+	.setName('slow-mode')
+	.setDescription('Configure slow mode for a channel')
+	.addSubcommandGroup(group => {
+		group.setName('enable')
+			.setDescription('Enable slow mode for a channel')
+			.addSubcommand(cmd => {
+				cmd.setName('auto')
+					.setDescription('Enable auto slow mode')
+					.addChannelOption(option => {
+						option.setName('channel')
+							.setDescription('The channel to enable auto slow mode for');
+						return option;
+					})
+					.addNumberOption(option => {
+						option.setName('window')
+							.setDescription('The time window to use for calculating message rate')
+							.setMinValue(10000);
+						return option;
+					});
+				return cmd;
+			})
+			.addSubcommand(cmd =>{
+				cmd.setName('static')
+					.setDescription('Enable static slow mode')
+					.addNumberOption(option => {
+						option.setName('limit')
+							.setDescription('The static limit to set the channel slow mode to')
+							.setMinValue(1)
+							.setRequired(true);
+						return option;
+					})
+					.addChannelOption(option => {
+						option.setName('channel')
+							.setDescription('The channel to enable static slow mode for');
+						return option;
+					});
+				return cmd;
+			});
+		return group;
+	})
+	.addSubcommand(cmd => {
+		cmd.setName('disable')
+			.setDescription('Disable slow mode for a channel')
+			.addChannelOption(option => {
+				option.setName('channel')
+					.setDescription('The channel to disable auto slow mode for');
+				return option;
+			});
+		return cmd;
+	})
+	.addSubcommand(cmd => {
+		cmd.setName('stats')
+			.setDescription('Get the current auto slow mode stats for a channel')
+			.addChannelOption(option => {
+				option.setName('channel')
+					.setDescription('The channel to fetch the auto slow mode stats for');
+				return option;
+			});
+		return cmd;
+	})
+	.addSubcommandGroup(group => {
+		group.setName('stage')
+			.setDescription('Managed the auto slow mode threshold settings')
+			.addSubcommand(cmd => {
+				cmd.setName('set')
+					.setDescription('Set the properties of a stage for the given channel')
+					.addNumberOption(option => {
+						option.setName('threshold')
+							.setDescription('the threshold in messages per section that must be reached to enable this stage')
+							.setRequired(true)
+							.setMinValue(0);
+						return option;
+					})
+					.addNumberOption(option => {
+						option.setName('limit')
+							.setDescription('the limit to apply to the channel once the threshold has been reached')
+							.setRequired(true)
+							.setMinValue(0);
+						return option;
+					})
+					.addChannelOption(option => {
+						option.setName('channel')
+							.setDescription('The channel to add a threshold for');
+						return option;
+					});
+				return cmd;
+			})
+			.addSubcommand(cmd => {
+				cmd.setName('unset')
+					.setDescription('Unset a stage for the given channel')
+					.addNumberOption(option => {
+						option.setName('threshold')
+							.setDescription('The index of the threshold to remove')
+							.setRequired(true);
+						return option;
+					})
+					.addChannelOption(option => {
+						option.setName('channel')
+							.setDescription('The channel to remove a threshold for');
+						return option;
+					});
+				return cmd;
+			});
+		return group;
+	});
+
+export default {
+	name: command.name,
+	handler: slowModeHandler,
+	deploy: command.toJSON()
+};

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -158,7 +158,7 @@ async function unsetStageHandler(interaction: ChatInputCommandInteraction): Prom
 	}
 
 	const oldLimit = stage.limit;
-	await slowMode.destroy();
+	await stage.destroy();
 	await slowMode.reload({ include: 'stages' });
 
 	const auditLogEmbed = new EmbedBuilder()

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -421,18 +421,28 @@ async function slowModeStatsHandler(interaction: ChatInputCommandInteraction): P
 		});
 	
 	if (slowMode && slowMode.enabled) {
+		if (slowMode.users) {
+			embed.addFields([
+				{
+					name: 'Participating Users',
+					value: slowMode.users.toString()
+				}
+			]);
+		}
+		
+		if (slowMode.rate) {
+			embed.addFields([
+				{
+					name: 'Current Rate',
+					value: slowMode.rate.toString()
+				}
+			]);
+		}
+
 		embed.addFields([
 			{
-				name: 'Participating Users',
-				value: slowMode.users.toString()
-			},
-			{
-				name: 'Current Rate',
-				value: slowMode.rate.toString()
-			},
-			{
 				name: 'Current Limit',
-				value: `1 message every ${slowMode.limit} seconds`
+				value: `1 message every ${channel.rateLimitPerUser} seconds`
 			},
 			{
 				name: 'Window',

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -561,7 +561,7 @@ const command = new SlashCommandBuilder()
 						option.setName('limit')
 							.setDescription('the limit to apply to the channel once the threshold has been reached')
 							.setRequired(true)
-							.setMinValue(1)
+							.setMinValue(0)
 							.setMaxValue(21600);
 						return option;
 					})

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -6,32 +6,26 @@ import { ChannelType, EmbedBuilder } from 'discord.js';
 import type { GuildTextBasedChannel, ChatInputCommandInteraction } from 'discord.js';
 
 async function slowModeHandler(interaction: ChatInputCommandInteraction): Promise<void> {
-	switch (interaction.options.getSubcommandGroup()) {
-		case 'stage': {
-			switch (interaction.options.getSubcommand()) {
-				case 'set':
-					return setStageHandler(interaction);
-				case 'unset':
-					return unsetStageHandler(interaction);
-			}
-			break;
+	const subcommandGroup = interaction.options.getSubcommandGroup();
+	const subcommand = interaction.options.getSubcommand();
+
+	if (subcommandGroup === 'stage') {
+		if (subcommand === 'set') {
+			return setStageHandler(interaction);
+		} else if (subcommand === 'unset') {
+			return unsetStageHandler(interaction);
 		}
-		case 'enable': {
-			switch (interaction.options.getSubcommand()) {
-				case 'auto':
-					return enableAutoSlowModeHandler(interaction);
-				case 'static':
-					return enableStaticSlowModeHandler(interaction);
-			}
-			break;
+	} else if (subcommandGroup === 'enable') {
+		if (subcommand === 'auto') {
+			return enableAutoSlowModeHandler(interaction);
+		} else {
+			return enableStaticSlowModeHandler(interaction);
 		}
-		case null: {
-			switch (interaction.options.getSubcommand()) {
-				case 'disable':
-					return disableSlowModeHandler(interaction);
-				case 'stats':
-					return slowModeStatsHandler(interaction);
-			}
+	} else {
+		if (subcommand === 'disable') {
+			return disableSlowModeHandler(interaction);
+		} else if (subcommand === 'stats') {
+			return slowModeStatsHandler(interaction);
 		}
 	}
 
@@ -50,7 +44,7 @@ async function setStageHandler(interaction: ChatInputCommandInteraction): Promis
 		throw new Error('Slow mode only applies to text channels');
 	}
 
-	const [ slowMode, ] = await SlowMode.findOrCreate({
+	const [slowMode, _] = await SlowMode.findOrCreate({
 		where: {
 			channel_id: channel.id
 		},

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -241,7 +241,7 @@ async function enableAutoSlowModeHandler(interaction: ChatInputCommandInteractio
 
 	if (!enabled) {
 		// * This returns a Promise but is specifically not awaited as it should spawn its own loop
-		handleSlowMode(interaction.guild!, slowMode);
+		handleSlowMode(interaction.client, slowMode);
 	}
 
 	const auditLogEmbed = new EmbedBuilder()

--- a/src/commands/slow-mode.ts
+++ b/src/commands/slow-mode.ts
@@ -158,7 +158,7 @@ async function unsetStageHandler(interaction: ChatInputCommandInteraction): Prom
 	}
 
 	const oldLimit = stage.limit;
-	await slowMode.removeStage(stage);
+	await slowMode.destroy();
 	await slowMode.reload({ include: 'stages' });
 
 	const auditLogEmbed = new EmbedBuilder()

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -7,6 +7,7 @@ import settingsCommand from '@/commands/settings';
 import warnCommand from '@/commands/warn';
 import modpingCommand from '@/commands/modping';
 import messageLogContextMenu from '@/context-menus/messages/message-log';
+import slowModeCommand from '@/commands/slow-mode';
 import { checkMatchmakingThreads } from '@/matchmaking-threads';
 import { loadModel } from '@/check-nsfw';
 import type { Database } from 'sqlite3';
@@ -15,7 +16,7 @@ import config from '@/config.json';
 
 export default async function readyHandler(client: Client): Promise<void> {
 	console.log('Registering global commands');
-	loadBotHandlersCollection('commands', client);
+	loadBotHandlersCollection(client);
 
 	console.log('Establishing DB connection');
 	await sequelize.sync(config.sequelize);
@@ -41,12 +42,13 @@ export default async function readyHandler(client: Client): Promise<void> {
 	await checkMatchmakingThreads();
 }
 
-function loadBotHandlersCollection(name: string, client: Client): void {
+function loadBotHandlersCollection(client: Client): void {
 	client.commands.set(banCommand.name, banCommand);
 	client.commands.set(kickCommand.name, kickCommand);
 	client.commands.set(settingsCommand.name, settingsCommand);
 	client.commands.set(warnCommand.name, warnCommand);
 	client.commands.set(modpingCommand.name, modpingCommand);
+	client.commands.set(slowModeCommand.name, slowModeCommand);
 
 	client.contextMenus.set(messageLogContextMenu.name, messageLogContextMenu);
 }

--- a/src/models/slow-mode.ts
+++ b/src/models/slow-mode.ts
@@ -1,0 +1,101 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '@/sequelize-instance';
+import type {
+	Association,
+	CreationOptional,
+	ForeignKey,
+	HasManyAddAssociationMixin,
+	HasManyAddAssociationsMixin,
+	HasManyCountAssociationsMixin,
+	HasManyCreateAssociationMixin,
+	HasManyGetAssociationsMixin,
+	HasManyHasAssociationMixin,
+	HasManyHasAssociationsMixin,
+	HasManyRemoveAssociationMixin,
+	HasManyRemoveAssociationsMixin,
+	HasManySetAssociationsMixin,
+	InferAttributes,
+	InferCreationAttributes,
+	NonAttribute
+} from 'sequelize';
+
+export class SlowMode extends Model<InferAttributes<SlowMode, { omit: 'stages' }>, InferCreationAttributes<SlowMode, { omit: 'stages' }>> {
+	declare id: CreationOptional<number>;
+	declare channel_id: string;
+	declare window: CreationOptional<number>;
+	declare enabled: CreationOptional<boolean>;
+	declare users: CreationOptional<number>;
+	declare rate: CreationOptional<number>;
+	declare limit: CreationOptional<number>;
+
+	declare getStages: HasManyGetAssociationsMixin<SlowModeStage>; // Note the null assertions!
+	declare addStage: HasManyAddAssociationMixin<SlowModeStage, number>;
+	declare addStages: HasManyAddAssociationsMixin<SlowModeStage, number>;
+	declare setStages: HasManySetAssociationsMixin<SlowModeStage, number>;
+	declare removeStage: HasManyRemoveAssociationMixin<SlowModeStage, number>;
+	declare removeStages: HasManyRemoveAssociationsMixin<SlowModeStage, number>;
+	declare hasStage: HasManyHasAssociationMixin<SlowModeStage, number>;
+	declare hasStages: HasManyHasAssociationsMixin<SlowModeStage, number>;
+	declare countStages: HasManyCountAssociationsMixin;
+	declare createStage: HasManyCreateAssociationMixin<SlowModeStage, 'ownerId'>;
+	declare stages?: NonAttribute<SlowModeStage[]>;
+
+	declare static associations: {
+		stages: Association<SlowMode, SlowModeStage>;
+	}
+}
+
+SlowMode.init({
+	id: {
+		type: DataTypes.INTEGER,
+		autoIncrement: true,
+		primaryKey: true
+	},
+	channel_id: {
+		type: DataTypes.STRING,
+		unique: true
+	},
+	enabled: {
+		type: DataTypes.BOOLEAN,
+		defaultValue: true
+	},
+	window: {
+		type: DataTypes.NUMBER,
+		defaultValue: 60000
+	},
+	users: {
+		type: DataTypes.NUMBER
+	},
+	rate: {
+		type: DataTypes.NUMBER
+	},
+	limit: {
+		type: DataTypes.NUMBER
+	}
+}, { sequelize, tableName: 'slow-mode' });
+
+export class SlowModeStage extends Model<InferAttributes<SlowModeStage>, InferCreationAttributes<SlowModeStage>> {
+	declare id: CreationOptional<number>;
+	declare threshold: number;
+	declare limit: number;
+
+	declare ownerId: ForeignKey<SlowMode['id']>;
+	declare owner?: NonAttribute<SlowMode>;
+}
+
+SlowModeStage.init({
+	id: {
+		type: DataTypes.INTEGER,
+		autoIncrement: true,
+		primaryKey: true
+	},
+	threshold: {
+		type: DataTypes.NUMBER
+	},
+	limit: {
+		type: DataTypes.NUMBER
+	}
+}, { sequelize, tableName: 'slow-mode-threshold' });
+
+SlowMode.hasMany(SlowModeStage, { as: 'stages' });
+SlowModeStage.belongsTo(SlowMode);

--- a/src/models/slow-mode.ts
+++ b/src/models/slow-mode.ts
@@ -24,9 +24,8 @@ export class SlowMode extends Model<InferAttributes<SlowMode, { omit: 'stages' }
 	declare channel_id: string;
 	declare window: CreationOptional<number>;
 	declare enabled: CreationOptional<boolean>;
-	declare users: CreationOptional<number>;
-	declare rate: CreationOptional<number>;
-	declare limit: CreationOptional<number>;
+	declare users?: CreationOptional<number>;
+	declare rate?: CreationOptional<number>;
 
 	declare getStages: HasManyGetAssociationsMixin<SlowModeStage>; // Note the null assertions!
 	declare addStage: HasManyAddAssociationMixin<SlowModeStage, number>;
@@ -64,13 +63,12 @@ SlowMode.init({
 		defaultValue: 60000
 	},
 	users: {
-		type: DataTypes.NUMBER
+		type: DataTypes.NUMBER,
+		allowNull: true
 	},
 	rate: {
-		type: DataTypes.NUMBER
-	},
-	limit: {
-		type: DataTypes.NUMBER
+		type: DataTypes.NUMBER,
+		allowNull: true
 	}
 }, { sequelize, tableName: 'slow-mode' });
 

--- a/src/models/slow-mode.ts
+++ b/src/models/slow-mode.ts
@@ -27,7 +27,7 @@ export class SlowMode extends Model<InferAttributes<SlowMode>, InferCreationAttr
 	declare users?: CreationOptional<number>;
 	declare rate?: CreationOptional<number>;
 
-	declare getStages: HasManyGetAssociationsMixin<SlowModeStage>; // Note the null assertions!
+	declare getStages: HasManyGetAssociationsMixin<SlowModeStage>;
 	declare addStage: HasManyAddAssociationMixin<SlowModeStage, number>;
 	declare addStages: HasManyAddAssociationsMixin<SlowModeStage, number>;
 	declare setStages: HasManySetAssociationsMixin<SlowModeStage, number>;

--- a/src/models/slow-mode.ts
+++ b/src/models/slow-mode.ts
@@ -19,7 +19,7 @@ import type {
 	NonAttribute
 } from 'sequelize';
 
-export class SlowMode extends Model<InferAttributes<SlowMode, { omit: 'stages' }>, InferCreationAttributes<SlowMode, { omit: 'stages' }>> {
+export class SlowMode extends Model<InferAttributes<SlowMode>, InferCreationAttributes<SlowMode>> {
 	declare id: CreationOptional<number>;
 	declare channel_id: string;
 	declare window: CreationOptional<number>;

--- a/src/setup-guild.ts
+++ b/src/setup-guild.ts
@@ -1,23 +1,28 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v10';
+import handleSlowMode from '@/slow-mode';
+import { SlowMode } from '@/models/slow-mode';
 import { bot_token as botToken } from '@/config.json';
 import type { Guild } from 'discord.js';
 
 const rest = new REST({ version: '10' }).setToken(botToken);
 
 export async function setupGuild(guild: Guild): Promise<void> {
-	// do nothing if the bot does not have the correct permissions
+	// * Do nothing if the bot does not have the correct permissions
 	if (!guild.members.me!.permissions.has([PermissionFlagsBits.ManageRoles, PermissionFlagsBits.ManageChannels])) {
 		console.log('Bot does not have permissions to set up in guild', guild.name);
 		return;
 	}
 
-	// Populate members cache
+	// * Populate members cache
 	await guild.members.fetch();
 
-	// Setup commands
+	// * Setup commands
 	await deployCommands(guild);
+
+	// * Setup slow mode
+	await setupSlowMode(guild);
 }
 
 async function deployCommands(guild: Guild): Promise<void> {
@@ -33,4 +38,15 @@ async function deployCommands(guild: Guild): Promise<void> {
 	await rest.put(Routes.applicationGuildCommands(guild.members.me!.id, guild.id), {
 		body: [...commands, ...contextMenus],
 	});
+}
+
+async function setupSlowMode(guild: Guild): Promise<void> {
+	const slowModes = await SlowMode.findAll({
+		where: {
+			enabled: true
+		},
+		include: { all: true }
+	});
+
+	slowModes.forEach(slowMode => handleSlowMode(guild, slowMode));
 }

--- a/src/setup-guild.ts
+++ b/src/setup-guild.ts
@@ -1,8 +1,6 @@
 import { PermissionFlagsBits } from 'discord.js';
 import { REST } from '@discordjs/rest';
 import { Routes } from 'discord-api-types/v10';
-import handleSlowMode from '@/slow-mode';
-import { SlowMode } from '@/models/slow-mode';
 import { bot_token as botToken } from '@/config.json';
 import type { Guild } from 'discord.js';
 
@@ -20,9 +18,6 @@ export async function setupGuild(guild: Guild): Promise<void> {
 
 	// * Setup commands
 	await deployCommands(guild);
-
-	// * Setup slow mode
-	await setupSlowMode(guild);
 }
 
 async function deployCommands(guild: Guild): Promise<void> {
@@ -38,15 +33,4 @@ async function deployCommands(guild: Guild): Promise<void> {
 	await rest.put(Routes.applicationGuildCommands(guild.members.me!.id, guild.id), {
 		body: [...commands, ...contextMenus],
 	});
-}
-
-async function setupSlowMode(guild: Guild): Promise<void> {
-	const slowModes = await SlowMode.findAll({
-		where: {
-			enabled: true
-		},
-		include: { all: true }
-	});
-
-	slowModes.forEach(slowMode => handleSlowMode(guild, slowMode));
 }

--- a/src/slow-mode.ts
+++ b/src/slow-mode.ts
@@ -1,10 +1,10 @@
 import { ChannelType, PermissionsBitField } from 'discord.js';
 import { sequelize } from '@/sequelize-instance';
 import type { SlowMode } from '@/models/slow-mode';
-import type { Guild, Message } from 'discord.js';
+import type { Client, Message } from 'discord.js';
 
-export default async function handleSlowMode(guild: Guild, slowMode: SlowMode): Promise<void> {
-	const channel = await guild.channels.fetch(slowMode.channel_id);
+export default async function handleSlowMode(client: Client, slowMode: SlowMode): Promise<void> {
+	const channel = await client.channels.fetch(slowMode.channel_id);
 	if (channel === null || channel.type !== ChannelType.GuildText) {
 		return;
 	}

--- a/src/slow-mode.ts
+++ b/src/slow-mode.ts
@@ -44,4 +44,6 @@ export default async function handleSlowMode(client: Client, slowMode: SlowMode)
 			await slowMode.save({ transaction });
 		});
 	}
+
+	console.log(`Slow mode stopped for ${channel.name}`);
 }

--- a/src/slow-mode.ts
+++ b/src/slow-mode.ts
@@ -1,0 +1,51 @@
+import { ChannelType, PermissionsBitField } from 'discord.js';
+import { sequelize } from '@/sequelize-instance';
+import type { SlowMode } from '@/models/slow-mode';
+import type { Guild, Message } from 'discord.js';
+
+export default async function handleSlowMode(guild: Guild, slowMode: SlowMode): Promise<void> {
+	const channel = await guild.channels.fetch(slowMode.channel_id);
+	if (channel === null || channel.type !== ChannelType.GuildText) {
+		return;
+	}
+
+	const filter = async (message: Message): Promise<boolean> => {
+		// * This prevents people who are immune to slow mode from counting towards the message rate
+		const permissions = channel.permissionsFor(message.member!);
+		return !permissions.has([PermissionsBitField.Flags.ManageMessages, PermissionsBitField.Flags.ManageChannels]);
+	};
+
+	if (slowMode.enabled) {
+		console.log(`Slow mode starting for ${channel.name}`);
+	}
+
+	while (slowMode.enabled) {
+		const messages = await channel.awaitMessages({ time: slowMode.window, filter });
+		const messageCount = messages.size;
+		
+		await sequelize.transaction(async transaction => {
+			await slowMode.reload({ include: 'stages', transaction });
+
+			// * Calculates the rate of messages per minute
+			const rate = (60000 / slowMode.window) * messageCount;
+			const users = new Set(messages.map(message => message.author.id));
+
+			const stage = (slowMode.stages ?? [])
+				.filter(stage => rate >= stage.threshold)
+				.sort((a, b) => b.threshold - a.threshold)[0];
+
+			if (stage && channel.rateLimitPerUser !== stage.limit) {
+				await channel.setRateLimitPerUser(stage.limit);
+			}
+
+			slowMode.users = users.size;
+			slowMode.rate = rate;
+
+			if (stage) {
+				slowMode.limit = stage.limit;
+			}
+
+			await slowMode.save({ transaction });
+		});
+	}
+}

--- a/src/slow-mode.ts
+++ b/src/slow-mode.ts
@@ -41,10 +41,6 @@ export default async function handleSlowMode(guild: Guild, slowMode: SlowMode): 
 			slowMode.users = users.size;
 			slowMode.rate = rate;
 
-			if (stage) {
-				slowMode.limit = stage.limit;
-			}
-
 			await slowMode.save({ transaction });
 		});
 	}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #15 

### Changes:

This adds a `/slow-mode` command which will allow moderators to manage slow mode settings for text channels. All actions from the command are logged in the event log.

All `/slow-mode` commands optionally accept a channel to apply to, if omitted the command will apply to the current channel.

`/slow-mode disable <channel>` will disable whatever slow mode is currently configured for a channel. 

#### Static slow mode
This is the standard slow mode available from discord. It can be administered as follows:
```
/slow-mode enable static 10
```
Would apply a static slow mode which limits users to 1 message every 10 seconds in the current channel. If there is a dynamic slow mode set, this will replace the dynamic settings.

#### Dynamic Slow Mode
This adds a way to configure slow mode that will be applied to a channel based on the rate of messages in that channel. This will allow the slow mode to be automatically adjusted depending on channel activity. 

The dynamic slow mode is configured with *stages* where each stage is made up of:
- A threshold that the rate of messages in the channel must reach before this stage is activated (**NOTE: The rate is worked out as messages in a channel per minute and so a threshold of `60` means `60 requests per minute`**)
- A limit which is the limit which will be imposed if this threshold is reached e.g. a limit of `10` means that each user can send 1 message every 10 seconds.

Stages are displayed in event logs and stats (See below) in the format:
```
1 message every {limit} seconds above {threshold} messages per minute
```

Stages are added by the `/slow-mode stage set <threshold> <limit> <channel>` command, where `channel` is optional and will default to the current channel. Only one stage can be set for each threshold, if you set a stage which already exists, it will update the limit for that stage.

You can also remove a stage at a particular threshold by using `/slow-mode stage unset <threshold> <channel>`

If a stage has a threshold of 0, it will be applied even when there are no messages being sent in the channel.

When enabling the dynamic slow mode there is also an optional `window` parameter which specifies how frequently the slow mode should change. Lower values will mean that the slow mode changes more quickly based on changes in message frequency, but it will be more prone to large changes. Larger values will take longer to take affect but will generally be more stable. The setting is given in milliseconds, the default is 60,000 (60 seconds) and the minimum value is 10,000 (10 seconds)

##### Example
Let's say we've got a dynamic slow mode set up with a window of 30000 and the following stages:
- 1 message every 30 seconds above 100 messages per minute
- 1 message every 60 seconds above 1000 messages per minute

This means that:
- Every 30 seconds Chubby will look at how many messages have been sent in this channel and work out the rate per minute
- If the rate is between 0 and 100 messages per minute there will be _no slow mode enabled in this channel_
- If the rate is between 100 and 1000 messages per minute a slow mode restricting users to 1 message every 30 seconds will be enabled
- If the rate is over 1000 messages per minute a slow mode restricting users to 1 message every 30 seconds will be enabled

##### Stats
As it can be difficult to work out what a good setting may be for a particular stage, there is an additional command `/slow-mode stats <channel>` which gives you information on both what the current settings are but also some useful stats about the current rate of messages in the channel. It shows:
- Number of users who sent messages in the channel over the last window
- Rate of messages over the last window
- The stage that was set based on this rate
- The window that's set
- The list of stages configured for this channel

I've tried to design these commands to be easy to reason about and easy to change, while not necessarily being as powerful of a system as we could have designed. I think this should work well if we can spend some time getting the configuration right for the larger channels

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.