### PR TITLE
Use user notifications everywhere

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -3,6 +3,7 @@ import { SlashCommandBuilder } from '@discordjs/builders';
 import { Ban } from '@/models/bans';
 import { sendEventLogMessage, ordinal } from '@/util';
 import { untrustUser } from '@/leveling';
+import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction } from 'discord.js';
 
 async function banHandler(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -65,7 +66,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 		});
 
 		await sendEventLogMessage(guild, null, eventLogEmbed);
-		
+
 		const { count, rows } = await Ban.findAndCountAll({
 			where: {
 				user_id: member.id
@@ -131,9 +132,9 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 			sendMemberEmbeds.push(pastBansEmbed);
 		}
 
-		await member.send({
+		await notifyUser(guild, user, {
 			embeds: sendMemberEmbeds
-		}).catch(() => console.log('Failed to DM user'));
+		});
 
 		await member.ban({
 			reason: reason

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -4,6 +4,7 @@ import { Kick } from '@/models/kicks';
 import { Ban } from '@/models/bans';
 import { ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
+import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction } from 'discord.js';
 
 async function kickHandler(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -77,7 +78,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		if (count >= 2) { // Atleast 2 previous kicks, this would be the 3rd strike. Ban
 			eventLogEmbed.setColor(0xF24E43);
 			eventLogEmbed.setTitle('Event Type: _Member Banned_');
-			
+
 			const banEmbed = new EmbedBuilder();
 
 			banEmbed.setTitle('Punishment Details');
@@ -172,9 +173,9 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			sendMemberEmbeds.push(pastKicksEmbed);
 		}
 
-		await member.send({
+		await notifyUser(guild, user, {
 			embeds: sendMemberEmbeds
-		}).catch(() => console.log('Failed to DM user'));
+		});
 
 		if (isKick) {
 			await member.kick(reason);

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -5,6 +5,7 @@ import { Kick } from '@/models/kicks';
 import { Ban } from '@/models/bans';
 import { ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
+import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction } from 'discord.js';
 
 async function warnHandler(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -176,9 +177,9 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 				);
 			}
 
-			await member.send({
+			await notifyUser(guild, user, {
 				embeds: [punishmentEmbed, pastWarningsEmbed]
-			}).catch(() => console.log('Failed to DM user'));
+			});
 
 			if (isKick) {
 				await member.kick(reason);
@@ -237,9 +238,9 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 				}
 			);
 
-			await member.send({
+			await notifyUser(guild, user, {
 				embeds: [punishmentEmbed]
-			}).catch(() => console.log('Failed to DM user'));
+			});
 		}
 
 		await Warning.create({

--- a/src/leveling.ts
+++ b/src/leveling.ts
@@ -122,7 +122,6 @@ export async function handleLeveling(message: Message): Promise<void> {
 		});
 
 		notifyUser(guild, message.author, {
-			content: '',
 			embeds: [notificationEmbed]
 		});
 

--- a/src/matchmaking-threads.ts
+++ b/src/matchmaking-threads.ts
@@ -4,6 +4,7 @@ import { MatchmakingThread } from '@/models/matchmakingThreads';
 import { User } from '@/models/users';
 import { sendEventLogMessage } from '@/util';
 import { getDB } from '@/db';
+import { notifyUser } from '@/notifications';
 import type { Message } from 'discord.js';
 
 export async function handleMatchmakingThreadMessage(message: Message): Promise<void> {
@@ -104,18 +105,14 @@ export async function checkMatchmakingThreads(): Promise<void> {
 							iconURL: guild.iconURL()!
 						});
 
-						try {
-							//TODO - Switch this to the new DM/notification channel system
-							await creatorUser.send({
-								embeds: [notificationEmbed]
-							});
-							await User.upsert({
-								user_id: threadChannel.ownerId,
-								matchmaking_notification_sent: true
-							});
-						} catch (error) {
-							console.log('Failed to DM user');
-						}
+						await notifyUser(guild, creatorUser, {
+							embeds: [notificationEmbed]
+						});
+
+						await User.upsert({
+							user_id: threadChannel.ownerId,
+							matchmaking_notification_sent: true
+						});
 					}
 				}
 

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -55,7 +55,7 @@ async function notifyUserInChannel(guild: Guild, user: User, message: string | M
 	if (typeof message === 'string') {
 		message = `<@${user.id}>\n${message}`;
 	} else {
-		message.content = `<@${user.id}>\n${message.content}`;
+		message.content = `<@${user.id}>\n${message.content ?? ''}`;
 	}
 
 	await thread.send(message);


### PR DESCRIPTION
Resolves #27

### Changes:

This changes all instances of explicitly sending a user a DM to the use the notification threads fallback, including matchmaking threads and moderation commands. I changed kicks and bans to use `notifyUser` just for consistency purposes, but the user would not be able to see the notification thread until they rejoin. This could be reverted if that makes more sense.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.