### PR TITLE
Add delete messages option to /kick and /ban

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -15,6 +15,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	const executor = interaction.user;
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
+	const deleteMessages = interaction.options.getNumber('delete_messages');
 
 	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
 
@@ -54,6 +55,10 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 			{
 				name: 'Reason',
 				value: reason
+			},
+			{
+				name: 'Delete Messages (seconds)',
+				value: deleteMessages?.toString() ?? 'No'
 			},
 			{
 				name: 'From bot /ban command',
@@ -137,7 +142,8 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 		});
 
 		await member.ban({
-			reason: reason
+			reason: reason,
+			deleteMessageSeconds: deleteMessages ?? undefined
 		});
 
 		await Ban.create({
@@ -167,6 +173,20 @@ const command = new SlashCommandBuilder()
 		return option.setName('reason')
 			.setDescription('Reason for the ban')
 			.setRequired(true);
+	})
+	.addNumberOption(option => {
+		return option.setName('delete_messages')
+			.setDescription('How much of their recent message history to delete')
+			.addChoices(
+				{ name: 'Previous 30 Minutes', value: 30 * 60 },
+				{ name: 'Previous Hour', value: 60 * 60 },
+				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
+				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
+				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
+				{ name: 'Previous Day', value: 24 * 60 * 60 },
+				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
+				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
+			);
 	});
 
 export default {

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -114,11 +114,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			sendMemberEmbeds.push(banEmbed);
 		} else { // Just kick
 			eventLogEmbed.setColor(0xEF7F31);
-			if (deleteMessages) {
-				eventLogEmbed.setTitle('Event Type: _Member Soft-Banned_');
-			} else {
-				eventLogEmbed.setTitle('Event Type: _Member Kicked_');
-			}
+			eventLogEmbed.setTitle('Event Type: _Member Kicked_');
 
 			const kickEmbed = new EmbedBuilder();
 
@@ -189,10 +185,10 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		if (isKick) {
 			if (deleteMessages) {
 				await member.ban({
-					reason: `Soft-ban: ${reason}`,
+					reason: `Kick with message deletion: ${reason}`,
 					deleteMessageSeconds: deleteMessages ?? undefined
 				});
-				await guild.members.unban(member, 'Soft-ban removed');
+				await guild.members.unban(member, 'Remove ban for kick with message deletion');
 			} else {
 				await member.kick(reason);
 			}
@@ -242,7 +238,7 @@ const command = new SlashCommandBuilder()
 	})
 	.addNumberOption(option => {
 		return option.setName('delete_messages')
-			.setDescription('How much of their recent message history to delete (turns this kick into a soft-ban)')
+			.setDescription('How much of their recent message history to delete')
 			.addChoices(
 				{ name: 'Previous 30 Minutes', value: 30 * 60 },
 				{ name: 'Previous Hour', value: 60 * 60 },

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -16,6 +16,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const executor = interaction.user;
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
+	const deleteMessages = interaction.options.getNumber('delete_messages');
 
 	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
 
@@ -53,6 +54,10 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			{
 				name: 'Reason',
 				value: reason
+			},
+			{
+				name: 'Delete Messages (seconds)',
+				value: deleteMessages?.toString() ?? 'No'
 			},
 			{
 				name: 'From bot /kick command',
@@ -109,7 +114,11 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			sendMemberEmbeds.push(banEmbed);
 		} else { // Just kick
 			eventLogEmbed.setColor(0xEF7F31);
-			eventLogEmbed.setTitle('Event Type: _Member Kicked_');
+			if (deleteMessages) {
+				eventLogEmbed.setTitle('Event Type: _Member Soft-Banned_');
+			} else {
+				eventLogEmbed.setTitle('Event Type: _Member Kicked_');
+			}
 
 			const kickEmbed = new EmbedBuilder();
 
@@ -178,10 +187,19 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		});
 
 		if (isKick) {
-			await member.kick(reason);
+			if (deleteMessages) {
+				await member.ban({
+					reason: `Soft-ban: ${reason}`,
+					deleteMessageSeconds: deleteMessages ?? undefined
+				});
+				await guild.members.unban(member, 'Soft-ban removed');
+			} else {
+				await member.kick(reason);
+			}
 		} else if (isBan) {
 			await member.ban({
-				reason
+				reason,
+				deleteMessageSeconds: deleteMessages ?? undefined
 			});
 
 			await Ban.create({
@@ -221,6 +239,20 @@ const command = new SlashCommandBuilder()
 		return option.setName('reason')
 			.setDescription('Reason for the kick')
 			.setRequired(true);
+	})
+	.addNumberOption(option => {
+		return option.setName('delete_messages')
+			.setDescription('How much of their recent message history to delete (turns this kick into a soft-ban)')
+			.addChoices(
+				{ name: 'Previous 30 Minutes', value: 30 * 60 },
+				{ name: 'Previous Hour', value: 60 * 60 },
+				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
+				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
+				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
+				{ name: 'Previous Day', value: 24 * 60 * 60 },
+				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
+				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
+			);
 	});
 
 export default {


### PR DESCRIPTION
Resolves #33

### Changes:

This adds an option to delete messages to both /kick and /ban. Using the option with /ban simply passes the option directly to the ban. Using the option with /kick turns the kick into a soft-ban, which uses a ban with message deletion and immediate unban to effectively kick the user. Soft-bans are logged and stored as kicks because they are effectively kicks.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.