### PR TITLE
Separate single and multi-user versions of commands

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -17,13 +17,13 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	let userIds;
+	let userIDs;
 	if (subcommand === 'user') {
 		const user = interaction.options.getUser('user', true);
-		userIds = [user.id];
+		userIDs = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
+		userIDs = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown ban subcommand: ${subcommand}`);
 	}
@@ -32,8 +32,8 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	bansListEmbed.setTitle('User Bans :thumbsdown:');
 	bansListEmbed.setColor(0xFFA500);
 
-	for (const userId of userIds) {
-		const member = await interaction.guild!.members.fetch(userId);
+	for (const userID of userIDs) {
+		const member = await interaction.guild!.members.fetch(userID);
 		const user = member.user;
 
 		await untrustUser(member, interaction.createdAt);

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -17,7 +17,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
+	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
 
 	const bansListEmbed = new EmbedBuilder();
 	bansListEmbed.setTitle('User Bans :thumbsdown:');

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -15,6 +15,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	const executor = interaction.user;
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
+	const deleteMessages = interaction.options.getNumber('delete_messages');
 
 	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
 
@@ -54,6 +55,10 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 			{
 				name: 'Reason',
 				value: reason
+			},
+			{
+				name: 'Delete Messages (seconds)',
+				value: deleteMessages?.toString() ?? 'No'
 			},
 			{
 				name: 'From bot /ban command',
@@ -137,7 +142,8 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 		});
 
 		await member.ban({
-			reason: reason
+			reason: reason,
+			deleteMessageSeconds: deleteMessages ?? undefined
 		});
 
 		await Ban.create({
@@ -167,6 +173,20 @@ const command = new SlashCommandBuilder()
 		return option.setName('reason')
 			.setDescription('Reason for the ban')
 			.setRequired(true);
+	})
+	.addNumberOption(option => {
+		return option.setName('delete_messages')
+			.setDescription('How much of their recent message history to delete')
+			.addChoices(
+				{ name: 'Previous 30 Minutes', value: 30 * 60 },
+				{ name: 'Previous Hour', value: 60 * 60 },
+				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
+				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
+				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
+				{ name: 'Previous Day', value: 24 * 60 * 60 },
+				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
+				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
+			);
 	});
 
 export default {

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -23,7 +23,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 		userIds = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown ban subcommand: ${subcommand}`);
 	}

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, MessageMentions } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Ban } from '@/models/bans';
 import { sendEventLogMessage, ordinal } from '@/util';
@@ -17,7 +17,7 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
+	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
 
 	const bansListEmbed = new EmbedBuilder();
 	bansListEmbed.setTitle('User Bans :thumbsdown:');

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Ban } from '@/models/bans';
-import { sendEventLogMessage, ordinal } from '@/util';
+import { banMessageDeleteChoices, sendEventLogMessage, ordinal } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction } from 'discord.js';
@@ -13,11 +13,20 @@ async function banHandler(interaction: ChatInputCommandInteraction): Promise<voi
 
 	const guild = await interaction.guild!.fetch();
 	const executor = interaction.user;
-	const users = interaction.options.getString('users', true);
+	const subcommand = interaction.options.getSubcommand();
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users!.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+	let userIds;
+	if (subcommand === 'user') {
+		const user = interaction.options.getUser('user', true);
+		userIds = [user.id];
+	} else if (subcommand === 'multiuser') {
+		const users = interaction.options.getString('users', true);
+		userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+	} else {
+		throw new Error(`Unknown ban subcommand: ${subcommand}`);
+	}
 
 	const bansListEmbed = new EmbedBuilder();
 	bansListEmbed.setTitle('User Bans :thumbsdown:');
@@ -164,30 +173,38 @@ const command = new SlashCommandBuilder()
 	.setDefaultMemberPermissions('0')
 	.setName('ban')
 	.setDescription('Ban user(s)')
-	.addStringOption(option => {
-		return option.setName('users')
-			.setDescription('User(s) to ban')
-			.setRequired(true);
-	})
-	.addStringOption(option => {
-		return option.setName('reason')
-			.setDescription('Reason for the ban')
-			.setRequired(true);
-	})
-	.addNumberOption(option => {
-		return option.setName('delete_messages')
-			.setDescription('How much of their recent message history to delete')
-			.addChoices(
-				{ name: 'Previous 30 Minutes', value: 30 * 60 },
-				{ name: 'Previous Hour', value: 60 * 60 },
-				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
-				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
-				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
-				{ name: 'Previous Day', value: 24 * 60 * 60 },
-				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
-				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
-			);
-	});
+	.addSubcommand(subcommand =>
+		subcommand.setName('user')
+			.setDescription('Ban a single user')
+			.addUserOption(option =>
+				option.setName('user')
+					.setDescription('User to ban')
+					.setRequired(true))
+			.addStringOption(option =>
+				option.setName('reason')
+					.setDescription('Reason for the ban')
+					.setRequired(true))
+			.addNumberOption(option =>
+				option.setName('delete_messages')
+					.setDescription('How much of their recent message history to delete')
+					.addChoices(banMessageDeleteChoices))
+	)
+	.addSubcommand(subcommand =>
+		subcommand.setName('multiuser')
+			.setDescription('Ban multiple users')
+			.addStringOption(option =>
+				option.setName('users')
+					.setDescription('User(s) to ban')
+					.setRequired(true))
+			.addStringOption(option =>
+				option.setName('reason')
+					.setDescription('Reason for the ban')
+					.setRequired(true))
+			.addNumberOption(option =>
+				option.setName('delete_messages')
+					.setDescription('How much of their recent message history to delete')
+					.addChoices(banMessageDeleteChoices))
+	);
 
 export default {
 	name: command.name,

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -18,13 +18,13 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	let userIds;
+	let userIDs;
 	if (subcommand === 'user') {
 		const user = interaction.options.getUser('user', true);
-		userIds = [user.id];
+		userIDs = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
+		userIDs = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown kick subcommand: ${subcommand}`);
 	}
@@ -33,8 +33,8 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	kicksListEmbed.setTitle('User Kicks :thumbsdown:');
 	kicksListEmbed.setColor(0xFFA500);
 
-	for (const userId of userIds) {
-		const member = await interaction.guild!.members.fetch(userId);
+	for (const userID of userIDs) {
+		const member = await interaction.guild!.members.fetch(userID);
 		const user = member.user;
 
 		await untrustUser(member, interaction.createdAt);

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -18,7 +18,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
+	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
 
 	const kicksListEmbed = new EmbedBuilder();
 	kicksListEmbed.setTitle('User Kicks :thumbsdown:');

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -1,4 +1,4 @@
-import { MessageMentions, EmbedBuilder } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Kick } from '@/models/kicks';
 import { Ban } from '@/models/bans';
@@ -18,7 +18,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
+	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
 
 	const kicksListEmbed = new EmbedBuilder();
 	kicksListEmbed.setTitle('User Kicks :thumbsdown:');

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -114,11 +114,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			sendMemberEmbeds.push(banEmbed);
 		} else { // Just kick
 			eventLogEmbed.setColor(0xEF7F31);
-			if (deleteMessages) {
-				eventLogEmbed.setTitle('Event Type: _Member Soft-Banned_');
-			} else {
-				eventLogEmbed.setTitle('Event Type: _Member Kicked_');
-			}
+			eventLogEmbed.setTitle('Event Type: _Member Kicked_');
 
 			const kickEmbed = new EmbedBuilder();
 
@@ -189,10 +185,10 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		if (isKick) {
 			if (deleteMessages) {
 				await member.ban({
-					reason: `Soft-ban: ${reason}`,
+					reason: `Kick with message deletion: ${reason}`,
 					deleteMessageSeconds: deleteMessages ?? undefined
 				});
-				await guild.members.unban(member, 'Soft-ban removed');
+				await guild.members.unban(member, 'Remove ban for kick with message deletion');
 			} else {
 				await member.kick(reason);
 			}
@@ -242,7 +238,7 @@ const command = new SlashCommandBuilder()
 	})
 	.addNumberOption(option => {
 		return option.setName('delete_messages')
-			.setDescription('How much of their recent message history to delete (turns this kick into a soft-ban)')
+			.setDescription('How much of their recent message history to delete')
 			.addChoices(
 				{ name: 'Previous 30 Minutes', value: 30 * 60 },
 				{ name: 'Previous Hour', value: 60 * 60 },

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -16,6 +16,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const executor = interaction.user;
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
+	const deleteMessages = interaction.options.getNumber('delete_messages');
 
 	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
 
@@ -53,6 +54,10 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			{
 				name: 'Reason',
 				value: reason
+			},
+			{
+				name: 'Delete Messages (seconds)',
+				value: deleteMessages?.toString() ?? 'No'
 			},
 			{
 				name: 'From bot /kick command',
@@ -109,7 +114,11 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 			sendMemberEmbeds.push(banEmbed);
 		} else { // Just kick
 			eventLogEmbed.setColor(0xEF7F31);
-			eventLogEmbed.setTitle('Event Type: _Member Kicked_');
+			if (deleteMessages) {
+				eventLogEmbed.setTitle('Event Type: _Member Soft-Banned_');
+			} else {
+				eventLogEmbed.setTitle('Event Type: _Member Kicked_');
+			}
 
 			const kickEmbed = new EmbedBuilder();
 
@@ -178,10 +187,19 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		});
 
 		if (isKick) {
-			await member.kick(reason);
+			if (deleteMessages) {
+				await member.ban({
+					reason: `Soft-ban: ${reason}`,
+					deleteMessageSeconds: deleteMessages ?? undefined
+				});
+				await guild.members.unban(member, 'Soft-ban removed');
+			} else {
+				await member.kick(reason);
+			}
 		} else if (isBan) {
 			await member.ban({
-				reason
+				reason,
+				deleteMessageSeconds: deleteMessages ?? undefined
 			});
 
 			await Ban.create({
@@ -221,6 +239,20 @@ const command = new SlashCommandBuilder()
 		return option.setName('reason')
 			.setDescription('Reason for the kick')
 			.setRequired(true);
+	})
+	.addNumberOption(option => {
+		return option.setName('delete_messages')
+			.setDescription('How much of their recent message history to delete (turns this kick into a soft-ban)')
+			.addChoices(
+				{ name: 'Previous 30 Minutes', value: 30 * 60 },
+				{ name: 'Previous Hour', value: 60 * 60 },
+				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
+				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
+				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
+				{ name: 'Previous Day', value: 24 * 60 * 60 },
+				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
+				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
+			);
 	});
 
 export default {

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Kick } from '@/models/kicks';
 import { Ban } from '@/models/bans';
-import { ordinal, sendEventLogMessage } from '@/util';
+import { banMessageDeleteChoices, ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction } from 'discord.js';
@@ -14,11 +14,20 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 
 	const guild = await interaction.guild!.fetch();
 	const executor = interaction.user;
-	const users = interaction.options.getString('users', true);
+	const subcommand = interaction.options.getSubcommand();
 	const reason = interaction.options.getString('reason', true);
 	const deleteMessages = interaction.options.getNumber('delete_messages');
 
-	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+	let userIds;
+	if (subcommand === 'user') {
+		const user = interaction.options.getUser('user', true);
+		userIds = [user.id];
+	} else if (subcommand === 'multiuser') {
+		const users = interaction.options.getString('users', true);
+		userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+	} else {
+		throw new Error(`Unknown kick subcommand: ${subcommand}`);
+	}
 
 	const kicksListEmbed = new EmbedBuilder();
 	kicksListEmbed.setTitle('User Kicks :thumbsdown:');
@@ -226,30 +235,38 @@ const command = new SlashCommandBuilder()
 	.setDefaultMemberPermissions('0')
 	.setName('kick')
 	.setDescription('Kick user(s)')
-	.addStringOption(option => {
-		return option.setName('users')
-			.setDescription('User(s) to kick')
-			.setRequired(true);
-	})
-	.addStringOption(option => {
-		return option.setName('reason')
-			.setDescription('Reason for the kick')
-			.setRequired(true);
-	})
-	.addNumberOption(option => {
-		return option.setName('delete_messages')
-			.setDescription('How much of their recent message history to delete')
-			.addChoices(
-				{ name: 'Previous 30 Minutes', value: 30 * 60 },
-				{ name: 'Previous Hour', value: 60 * 60 },
-				{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
-				{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
-				{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
-				{ name: 'Previous Day', value: 24 * 60 * 60 },
-				{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
-				{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
-			);
-	});
+	.addSubcommand(subcommand =>
+		subcommand.setName('user')
+			.setDescription('Kick user')
+			.addUserOption(option =>
+				option.setName('user')
+					.setDescription('User to kick')
+					.setRequired(true))
+			.addStringOption(option =>
+				option.setName('reason')
+					.setDescription('Reason for the kick')
+					.setRequired(true))
+			.addNumberOption(option =>
+				option.setName('delete_messages')
+					.setDescription('How much of their recent message history to delete')
+					.addChoices(banMessageDeleteChoices))
+	)
+	.addSubcommand(subcommand =>
+		subcommand.setName('multiuser')
+			.setDescription('Kick multiple users')
+			.addStringOption(option =>
+				option.setName('users')
+					.setDescription('User(s) to kick')
+					.setRequired(true))
+			.addStringOption(option =>
+				option.setName('reason')
+					.setDescription('Reason for the kick')
+					.setRequired(true))
+			.addNumberOption(option =>
+				option.setName('delete_messages')
+					.setDescription('How much of their recent message history to delete')
+					.addChoices(banMessageDeleteChoices))
+	);
 
 export default {
 	name: command.name,

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -24,7 +24,7 @@ async function kickHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		userIds = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown kick subcommand: ${subcommand}`);
 	}

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -24,7 +24,7 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		userIds = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
+		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown warn subcommand: ${subcommand}`);
 	}

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -6,15 +6,9 @@ import { Ban } from '@/models/bans';
 import { ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, CommandInteraction, ModalSubmitInteraction } from 'discord.js';
 
-async function warnHandler(interaction: ChatInputCommandInteraction): Promise<void> {
-	await interaction.deferReply({
-		ephemeral: true
-	});
-
-	const guild = await interaction.guild!.fetch();
-	const executor = interaction.user;
+async function warnCommandHandler(interaction: ChatInputCommandInteraction): Promise<void> {
 	const subcommand = interaction.options.getSubcommand();
 	const reason = interaction.options.getString('reason', true);
 
@@ -28,6 +22,17 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	} else {
 		throw new Error(`Unknown warn subcommand: ${subcommand}`);
 	}
+
+	await warnHandler(interaction, userIDs, reason);
+}
+
+export async function warnHandler(interaction: CommandInteraction | ModalSubmitInteraction, userIDs: string[], reason: string): Promise<void> {
+	await interaction.deferReply({
+		ephemeral: true
+	});
+
+	const guild = await interaction.guild!.fetch();
+	const executor = interaction.user;
 
 	const warningListEmbed = new EmbedBuilder();
 	warningListEmbed.setTitle('User Warnings :thumbsdown:');
@@ -263,7 +268,7 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		]);
 	}
 
-	await interaction.editReply({ embeds: [warningListEmbed] });
+	await interaction.followUp({ embeds: [warningListEmbed], ephemeral: true });
 }
 
 const command = new SlashCommandBuilder()
@@ -301,6 +306,6 @@ const command = new SlashCommandBuilder()
 
 export default {
 	name: command.name,
-	handler: warnHandler,
+	handler: warnCommandHandler,
 	deploy: command.toJSON()
 };

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -18,7 +18,7 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
 
-	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
+	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/g)), match => match[0]))];
 
 	const warningListEmbed = new EmbedBuilder();
 	warningListEmbed.setTitle('User Warnings :thumbsdown:');

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, MessageMentions } from 'discord.js';
+import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Warning } from '@/models/warnings';
 import { Kick } from '@/models/kicks';
@@ -18,7 +18,7 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const users = interaction.options.getString('users', true);
 	const reason = interaction.options.getString('reason', true);
 
-	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(MessageMentions.UsersPattern, 'g')), match => match[1]))];
+	const userIds = [...new Set(Array.from(users.matchAll(new RegExp(/\d{17,18}/, 'g')), match => match[0]))];
 
 	const warningListEmbed = new EmbedBuilder();
 	warningListEmbed.setTitle('User Warnings :thumbsdown:');

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -18,13 +18,13 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	const subcommand = interaction.options.getSubcommand();
 	const reason = interaction.options.getString('reason', true);
 
-	let userIds;
+	let userIDs;
 	if (subcommand === 'user') {
 		const user = interaction.options.getUser('user', true);
-		userIds = [user.id];
+		userIDs = [user.id];
 	} else if (subcommand === 'multiuser') {
 		const users = interaction.options.getString('users', true);
-		userIds = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
+		userIDs = [...new Set(Array.from(users.matchAll(/\d{17,18}/g), match => match[0]))];
 	} else {
 		throw new Error(`Unknown warn subcommand: ${subcommand}`);
 	}
@@ -33,8 +33,8 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	warningListEmbed.setTitle('User Warnings :thumbsdown:');
 	warningListEmbed.setColor(0xFFA500);
 
-	for (const userId of userIds) {
-		const member = await interaction.guild!.members.fetch(userId);
+	for (const userID of userIDs) {
+		const member = await interaction.guild!.members.fetch(userID);
 		const user = member.user;
 
 		await untrustUser(member, interaction.createdAt);

--- a/src/context-menus/users/ban.ts
+++ b/src/context-menus/users/ban.ts
@@ -1,0 +1,79 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { banHandler } from '@/commands/ban';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function banContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('banReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const deleteMessagesInput = new TextInputBuilder()
+		.setCustomId('deleteMessages')
+		.setLabel('Delete recent message history (hours)')
+		.setPlaceholder('Leave blank to not delete any messages')
+		.setRequired(false)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const deleteMessagesActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(deleteMessagesInput);
+
+	const banModal = new ModalBuilder()
+		.setCustomId('banModal')
+		.setTitle(`Ban ${target.tag}`)
+		.addComponents(reasonActionRow, deleteMessagesActionRow);
+
+	await interaction.showModal(banModal);
+
+	let modalSubmitInteraction;
+	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for ban processing
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 14.5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'banModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('banReason');
+	const deleteMessagesText = modalSubmitInteraction.fields.getTextInputValue('deleteMessages');
+	const deleteMessages = parseFloat(deleteMessagesText) * 60 * 60 || null;
+
+	if (deleteMessages && (deleteMessages < 0 || deleteMessages > 7 * 24 * 60 * 60)) {
+		await modalSubmitInteraction.reply({
+			content: 'Message deletion time must be between 0 and 168 hours (7 days).',
+			ephemeral: true
+		});
+		return;
+	}
+
+	await banHandler(modalSubmitInteraction, [target.id], reason, deleteMessages);
+}
+
+const banContextMenu = new ContextMenuCommandBuilder()
+	.setName('Ban user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: banContextMenu.name,
+	handler: banContextMenuHandler,
+	deploy: banContextMenu.toJSON()
+};

--- a/src/context-menus/users/kick.ts
+++ b/src/context-menus/users/kick.ts
@@ -1,0 +1,79 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { kickHandler } from '@/commands/kick';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function kickContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('kickReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const deleteMessagesInput = new TextInputBuilder()
+		.setCustomId('deleteMessages')
+		.setLabel('Delete recent message history (hours)')
+		.setPlaceholder('Leave blank to not delete any messages')
+		.setRequired(false)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const deleteMessagesActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(deleteMessagesInput);
+
+	const kickModal = new ModalBuilder()
+		.setCustomId('kickModal')
+		.setTitle(`Kick ${target.tag}`)
+		.addComponents(reasonActionRow, deleteMessagesActionRow);
+
+	await interaction.showModal(kickModal);
+
+	let modalSubmitInteraction;
+	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for kick processing
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 14.5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'kickModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('kickReason');
+	const deleteMessagesText = modalSubmitInteraction.fields.getTextInputValue('deleteMessages');
+	const deleteMessages = parseFloat(deleteMessagesText) * 60 * 60 || null;
+
+	if (deleteMessages && (deleteMessages < 0 || deleteMessages > 7 * 24 * 60 * 60)) {
+		await modalSubmitInteraction.reply({
+			content: 'Message deletion time must be between 0 and 168 hours (7 days).',
+			ephemeral: true
+		});
+		return;
+	}
+
+	await kickHandler(modalSubmitInteraction, [target.id], reason, deleteMessages);
+}
+
+const kickContextMenu = new ContextMenuCommandBuilder()
+	.setName('Kick user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: kickContextMenu.name,
+	handler: kickContextMenuHandler,
+	deploy: kickContextMenu.toJSON()
+};

--- a/src/context-menus/users/warn.ts
+++ b/src/context-menus/users/warn.ts
@@ -1,0 +1,59 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { warnHandler } from '@/commands/warn';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function warnContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('warnReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const warnModal = new ModalBuilder()
+		.setCustomId('warnModal')
+		.setTitle(`Warn ${target.tag}`)
+		.addComponents(reasonActionRow);
+
+	await interaction.showModal(warnModal);
+
+	let modalSubmitInteraction;
+	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for warn processing
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 14.5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'warnModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('warnReason');
+
+	await warnHandler(modalSubmitInteraction, [target.id], reason);
+}
+
+const warnContextMenu = new ContextMenuCommandBuilder()
+	.setName('Warn user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: warnContextMenu.name,
+	handler: warnContextMenuHandler,
+	deploy: warnContextMenu.toJSON()
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,7 @@
 import buttonHandler from '@/handlers/button-handler';
 import commandHandler from '@/handlers/command-handler';
 import messageContextMenuHandler from '@/handlers/context-menu-handler';
-import type { Interaction } from 'discord.js'; 
+import type { Interaction } from 'discord.js';
 
 export default async function interactionCreateHandler(interaction: Interaction): Promise<void> {
 	try {
@@ -24,7 +24,7 @@ export default async function interactionCreateHandler(interaction: Interaction)
 
 		try {
 			if (interaction.replied || interaction.deferred) {
-				await interaction.editReply(payload);
+				await interaction.followUp(payload);
 			} else {
 				await interaction.reply(payload);
 			}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -8,6 +8,9 @@ import warnCommand from '@/commands/warn';
 import modpingCommand from '@/commands/modping';
 import messageLogContextMenu from '@/context-menus/messages/message-log';
 import slowModeCommand from '@/commands/slow-mode';
+import warnContextMenu from '@/context-menus/users/warn';
+import kickContextMenu from '@/context-menus/users/kick';
+import banContextMenu from '@/context-menus/users/ban';
 import { checkMatchmakingThreads } from '@/matchmaking-threads';
 import { loadModel } from '@/check-nsfw';
 import { SlowMode } from '@/models/slow-mode';
@@ -55,6 +58,9 @@ function loadBotHandlersCollection(client: Client): void {
 	client.commands.set(slowModeCommand.name, slowModeCommand);
 
 	client.contextMenus.set(messageLogContextMenu.name, messageLogContextMenu);
+	client.contextMenus.set(warnContextMenu.name, warnContextMenu);
+	client.contextMenus.set(kickContextMenu.name, kickContextMenu);
+	client.contextMenus.set(banContextMenu.name, banContextMenu);
 }
 
 async function setupSlowMode(client: Client): Promise<void> {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { getDB, getDBList } from '@/db';
 import { ChannelType } from 'discord.js';
-import type { Channel, EmbedBuilder, Guild, Role, Message } from 'discord.js';
+import type { Channel, EmbedBuilder, Guild, Role, Message, APIApplicationCommandOptionChoice } from 'discord.js';
 
 const ordinalRules = new Intl.PluralRules('en', {
 	type: 'ordinal'
@@ -12,6 +12,17 @@ const suffixes: Record<string, string> = {
 	few: 'rd',
 	other: 'th'
 };
+
+export const banMessageDeleteChoices: Array<APIApplicationCommandOptionChoice<number>> = [
+	{ name: 'Previous 30 Minutes', value: 30 * 60 },
+	{ name: 'Previous Hour', value: 60 * 60 },
+	{ name: 'Previous 3 Hours', value: 3 * 60 * 60 },
+	{ name: 'Previous 6 Hours', value: 6 * 60 * 60 },
+	{ name: 'Previous 12 Hours', value: 12 * 60 * 60 },
+	{ name: 'Previous Day', value: 24 * 60 * 60 },
+	{ name: 'Previous 3 Days', value: 3 * 24 * 60 * 60 },
+	{ name: 'Previous Week', value: 7 * 24 * 60 * 60 },
+];
 
 export function ordinal(number: number): string {
 	const category = ordinalRules.select(number);


### PR DESCRIPTION
Resolves #38

### Changes:

This changes the regex used to match users in the commands to allow both mentions and user IDs. This is a simple regex that matches a 17 or 18 numbers in a row.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.