### PR TITLE
Add context menus to commands

### DIFF
--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -6,15 +6,9 @@ import { Ban } from '@/models/bans';
 import { ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
-import type { ChatInputCommandInteraction } from 'discord.js';
+import type { ChatInputCommandInteraction, CommandInteraction, ModalSubmitInteraction } from 'discord.js';
 
-async function warnHandler(interaction: ChatInputCommandInteraction): Promise<void> {
-	await interaction.deferReply({
-		ephemeral: true
-	});
-
-	const guild = await interaction.guild!.fetch();
-	const executor = interaction.user;
+async function warnCommandHandler(interaction: ChatInputCommandInteraction): Promise<void> {
 	const subcommand = interaction.options.getSubcommand();
 	const reason = interaction.options.getString('reason', true);
 
@@ -28,6 +22,17 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 	} else {
 		throw new Error(`Unknown warn subcommand: ${subcommand}`);
 	}
+
+	await warnHandler(interaction, userIDs, reason);
+}
+
+export async function warnHandler(interaction: CommandInteraction | ModalSubmitInteraction, userIDs: string[], reason: string): Promise<void> {
+	await interaction.deferReply({
+		ephemeral: true
+	});
+
+	const guild = await interaction.guild!.fetch();
+	const executor = interaction.user;
 
 	const warningListEmbed = new EmbedBuilder();
 	warningListEmbed.setTitle('User Warnings :thumbsdown:');
@@ -263,7 +268,7 @@ async function warnHandler(interaction: ChatInputCommandInteraction): Promise<vo
 		]);
 	}
 
-	await interaction.editReply({ embeds: [warningListEmbed] });
+	await interaction.followUp({ embeds: [warningListEmbed], ephemeral: true });
 }
 
 const command = new SlashCommandBuilder()
@@ -301,6 +306,6 @@ const command = new SlashCommandBuilder()
 
 export default {
 	name: command.name,
-	handler: warnHandler,
+	handler: warnCommandHandler,
 	deploy: command.toJSON()
 };

--- a/src/context-menus/users/ban.ts
+++ b/src/context-menus/users/ban.ts
@@ -18,13 +18,23 @@ export async function banContextMenuHandler(interaction: UserContextMenuCommandI
 		.setRequired(true)
 		.setStyle(TextInputStyle.Short);
 
+	const deleteMessagesInput = new TextInputBuilder()
+		.setCustomId('deleteMessages')
+		.setLabel('Delete recent message history (hours)')
+		.setPlaceholder('Leave blank to not delete any messages')
+		.setRequired(false)
+		.setStyle(TextInputStyle.Short);
+
 	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
 		.addComponents(reasonInput);
+
+	const deleteMessagesActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(deleteMessagesInput);
 
 	const banModal = new ModalBuilder()
 		.setCustomId('banModal')
 		.setTitle(`Ban ${target.tag}`)
-		.addComponents(reasonActionRow);
+		.addComponents(reasonActionRow, deleteMessagesActionRow);
 
 	await interaction.showModal(banModal);
 
@@ -42,8 +52,18 @@ export async function banContextMenuHandler(interaction: UserContextMenuCommandI
 	}
 
 	const reason = modalSubmitInteraction.fields.getTextInputValue('banReason');
+	const deleteMessagesText = modalSubmitInteraction.fields.getTextInputValue('deleteMessages');
+	const deleteMessages = parseFloat(deleteMessagesText) * 60 * 60 || null;
 
-	await banHandler(modalSubmitInteraction, [target.id], reason);
+	if (deleteMessages && (deleteMessages < 0 || deleteMessages > 7 * 24 * 60 * 60)) {
+		await modalSubmitInteraction.reply({
+			content: 'Message deletion time must be between 0 and 168 hours (7 days).',
+			ephemeral: true
+		});
+		return;
+	}
+
+	await banHandler(modalSubmitInteraction, [target.id], reason, deleteMessages);
 }
 
 const banContextMenu = new ContextMenuCommandBuilder()

--- a/src/context-menus/users/ban.ts
+++ b/src/context-menus/users/ban.ts
@@ -40,8 +40,9 @@ export async function banContextMenuHandler(interaction: UserContextMenuCommandI
 
 	let modalSubmitInteraction;
 	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for ban processing
 		modalSubmitInteraction = await interaction.awaitModalSubmit({
-			time: 5 * 60 * 1000,
+			time: 14.5 * 60 * 1000,
 			filter: modalSubmitInteraction =>
 				modalSubmitInteraction.customId === 'banModal' &&
 				modalSubmitInteraction.user.id === interaction.user.id

--- a/src/context-menus/users/ban.ts
+++ b/src/context-menus/users/ban.ts
@@ -1,0 +1,58 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { banHandler } from '@/commands/ban';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function banContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('banReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const banModal = new ModalBuilder()
+		.setCustomId('banModal')
+		.setTitle(`Ban ${target.tag}`)
+		.addComponents(reasonActionRow);
+
+	await interaction.showModal(banModal);
+
+	let modalSubmitInteraction;
+	try {
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'banModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('banReason');
+
+	await banHandler(modalSubmitInteraction, [target.id], reason);
+}
+
+const banContextMenu = new ContextMenuCommandBuilder()
+	.setName('Ban user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: banContextMenu.name,
+	handler: banContextMenuHandler,
+	deploy: banContextMenu.toJSON()
+};

--- a/src/context-menus/users/kick.ts
+++ b/src/context-menus/users/kick.ts
@@ -40,8 +40,9 @@ export async function kickContextMenuHandler(interaction: UserContextMenuCommand
 
 	let modalSubmitInteraction;
 	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for kick processing
 		modalSubmitInteraction = await interaction.awaitModalSubmit({
-			time: 5 * 60 * 1000,
+			time: 14.5 * 60 * 1000,
 			filter: modalSubmitInteraction =>
 				modalSubmitInteraction.customId === 'kickModal' &&
 				modalSubmitInteraction.user.id === interaction.user.id

--- a/src/context-menus/users/kick.ts
+++ b/src/context-menus/users/kick.ts
@@ -1,0 +1,58 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { kickHandler } from '@/commands/kick';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function kickContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('kickReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const kickModal = new ModalBuilder()
+		.setCustomId('kickModal')
+		.setTitle(`Kick ${target.tag}`)
+		.addComponents(reasonActionRow);
+
+	await interaction.showModal(kickModal);
+
+	let modalSubmitInteraction;
+	try {
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'kickModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('kickReason');
+
+	await kickHandler(modalSubmitInteraction, [target.id], reason);
+}
+
+const kickContextMenu = new ContextMenuCommandBuilder()
+	.setName('Kick user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: kickContextMenu.name,
+	handler: kickContextMenuHandler,
+	deploy: kickContextMenu.toJSON()
+};

--- a/src/context-menus/users/kick.ts
+++ b/src/context-menus/users/kick.ts
@@ -18,13 +18,23 @@ export async function kickContextMenuHandler(interaction: UserContextMenuCommand
 		.setRequired(true)
 		.setStyle(TextInputStyle.Short);
 
+	const deleteMessagesInput = new TextInputBuilder()
+		.setCustomId('deleteMessages')
+		.setLabel('Delete recent message history (hours)')
+		.setPlaceholder('Leave blank to not delete any messages')
+		.setRequired(false)
+		.setStyle(TextInputStyle.Short);
+
 	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
 		.addComponents(reasonInput);
+
+	const deleteMessagesActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(deleteMessagesInput);
 
 	const kickModal = new ModalBuilder()
 		.setCustomId('kickModal')
 		.setTitle(`Kick ${target.tag}`)
-		.addComponents(reasonActionRow);
+		.addComponents(reasonActionRow, deleteMessagesActionRow);
 
 	await interaction.showModal(kickModal);
 
@@ -42,8 +52,18 @@ export async function kickContextMenuHandler(interaction: UserContextMenuCommand
 	}
 
 	const reason = modalSubmitInteraction.fields.getTextInputValue('kickReason');
+	const deleteMessagesText = modalSubmitInteraction.fields.getTextInputValue('deleteMessages');
+	const deleteMessages = parseFloat(deleteMessagesText) * 60 * 60 || null;
 
-	await kickHandler(modalSubmitInteraction, [target.id], reason);
+	if (deleteMessages && (deleteMessages < 0 || deleteMessages > 7 * 24 * 60 * 60)) {
+		await modalSubmitInteraction.reply({
+			content: 'Message deletion time must be between 0 and 168 hours (7 days).',
+			ephemeral: true
+		});
+		return;
+	}
+
+	await kickHandler(modalSubmitInteraction, [target.id], reason, deleteMessages);
 }
 
 const kickContextMenu = new ContextMenuCommandBuilder()

--- a/src/context-menus/users/warn.ts
+++ b/src/context-menus/users/warn.ts
@@ -1,0 +1,58 @@
+import {
+	ActionRowBuilder,
+	ApplicationCommandType,
+	ContextMenuCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle
+} from 'discord.js';
+import { warnHandler } from '@/commands/warn';
+import type { UserContextMenuCommandInteraction, ModalActionRowComponentBuilder} from 'discord.js';
+
+export async function warnContextMenuHandler(interaction: UserContextMenuCommandInteraction): Promise<void> {
+	const target = interaction.targetUser;
+
+	const reasonInput = new TextInputBuilder()
+		.setCustomId('warnReason')
+		.setLabel('Reason')
+		.setRequired(true)
+		.setStyle(TextInputStyle.Short);
+
+	const reasonActionRow = new ActionRowBuilder<ModalActionRowComponentBuilder>()
+		.addComponents(reasonInput);
+
+	const warnModal = new ModalBuilder()
+		.setCustomId('warnModal')
+		.setTitle(`Warn ${target.tag}`)
+		.addComponents(reasonActionRow);
+
+	await interaction.showModal(warnModal);
+
+	let modalSubmitInteraction;
+	try {
+		modalSubmitInteraction = await interaction.awaitModalSubmit({
+			time: 5 * 60 * 1000,
+			filter: modalSubmitInteraction =>
+				modalSubmitInteraction.customId === 'warnModal' &&
+				modalSubmitInteraction.user.id === interaction.user.id
+		});
+	} catch {
+		// * The user dismissed the modal or took too long to respond
+		return;
+	}
+
+	const reason = modalSubmitInteraction.fields.getTextInputValue('warnReason');
+
+	await warnHandler(modalSubmitInteraction, [target.id], reason);
+}
+
+const warnContextMenu = new ContextMenuCommandBuilder()
+	.setName('Warn user')
+	.setDefaultMemberPermissions('0')
+	.setType(ApplicationCommandType.User);
+
+export default {
+	name: warnContextMenu.name,
+	handler: warnContextMenuHandler,
+	deploy: warnContextMenu.toJSON()
+};

--- a/src/context-menus/users/warn.ts
+++ b/src/context-menus/users/warn.ts
@@ -30,8 +30,9 @@ export async function warnContextMenuHandler(interaction: UserContextMenuCommand
 
 	let modalSubmitInteraction;
 	try {
+		// * Interaction tokens are only valid for 15 minutes, leave some time for warn processing
 		modalSubmitInteraction = await interaction.awaitModalSubmit({
-			time: 5 * 60 * 1000,
+			time: 14.5 * 60 * 1000,
 			filter: modalSubmitInteraction =>
 				modalSubmitInteraction.customId === 'warnModal' &&
 				modalSubmitInteraction.user.id === interaction.user.id

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,7 @@
 import buttonHandler from '@/handlers/button-handler';
 import commandHandler from '@/handlers/command-handler';
 import messageContextMenuHandler from '@/handlers/context-menu-handler';
-import type { Interaction } from 'discord.js'; 
+import type { Interaction } from 'discord.js';
 
 export default async function interactionCreateHandler(interaction: Interaction): Promise<void> {
 	try {
@@ -24,7 +24,7 @@ export default async function interactionCreateHandler(interaction: Interaction)
 
 		try {
 			if (interaction.replied || interaction.deferred) {
-				await interaction.editReply(payload);
+				await interaction.followUp(payload);
 			} else {
 				await interaction.reply(payload);
 			}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -8,6 +8,9 @@ import warnCommand from '@/commands/warn';
 import modpingCommand from '@/commands/modping';
 import messageLogContextMenu from '@/context-menus/messages/message-log';
 import slowModeCommand from '@/commands/slow-mode';
+import warnContextMenu from '@/context-menus/users/warn';
+import kickContextMenu from '@/context-menus/users/kick';
+import banContextMenu from '@/context-menus/users/ban';
 import { checkMatchmakingThreads } from '@/matchmaking-threads';
 import { loadModel } from '@/check-nsfw';
 import { SlowMode } from '@/models/slow-mode';
@@ -55,6 +58,9 @@ function loadBotHandlersCollection(client: Client): void {
 	client.commands.set(slowModeCommand.name, slowModeCommand);
 
 	client.contextMenus.set(messageLogContextMenu.name, messageLogContextMenu);
+	client.contextMenus.set(warnContextMenu.name, warnContextMenu);
+	client.contextMenus.set(kickContextMenu.name, kickContextMenu);
+	client.contextMenus.set(banContextMenu.name, banContextMenu);
 }
 
 async function setupSlowMode(client: Client): Promise<void> {


### PR DESCRIPTION
Resolves #37

### Changes:

This adds context menus for the warn, kick, and ban commands. Each context menu first responds with a modal asking for a reason and, optionally, a number of hours of message history to delete. Unfortunately, modals currently only support text inputs, so adding a drop-down option for this like in Discord's default ban modal is not possible.

The command handlers were also refactored in order to reuse the same functions for the context menu and chat input commands.

Several uses of `interaction.editReply` were changed to `interaction.followUp` because an interaction that is responded to with a modal will have `interaction.replied` set to true, but attempting to edit the reply will fail because there is no message reply. This makes `interaction.followUp` usable in a wider variety of situations, so it is a better candidate for error handling. When responding to a deferred reply, they both have the same effect of updating it.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.