### PR TITLE
Add command to manage warns

### DIFF
--- a/src/commands/manage-warn.ts
+++ b/src/commands/manage-warn.ts
@@ -1,0 +1,113 @@
+import { EmbedBuilder } from 'discord.js';
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { Warning } from '@/models/warnings';
+import type { ChatInputCommandInteraction, CommandInteraction } from 'discord.js';
+
+async function manageWarnCommandHandler(interaction: ChatInputCommandInteraction): Promise<void> {
+	const subcommand = interaction.options.getSubcommand();
+
+	if (subcommand === 'view') {
+		const user = interaction.options.getUser('user', true);
+		await viewWarnHandler(interaction, user.id);
+		return;
+	} else if (subcommand === 'remove') {
+		const warnId = interaction.options.getString('id', true);
+		await removeWarnHandler(interaction, warnId);
+		return;
+	}
+
+	throw new Error(`Unknown warn subcommand: ${subcommand}`);
+}
+
+export async function viewWarnHandler(interaction: CommandInteraction, userId: string): Promise<void> {
+	await interaction.deferReply({
+		ephemeral: true
+	});
+
+	const member = await interaction.guild!.members.fetch(userId);
+
+	const { rows } = await Warning.findAndCountAll({
+		where: {
+			user_id: member.id,
+		}
+	});
+	const userWarnings = rows.map(v=>({
+		...v,
+		isExpired: v.expires_at < new Date(),
+	}));
+	const activeWarnings = userWarnings.filter(v=>!v.isExpired);
+
+	const warningListEmbed = new EmbedBuilder();
+	warningListEmbed.setTitle('Warning list :thumbsdown:');
+	warningListEmbed.setColor(0xFFA500);
+	warningListEmbed.setDescription(`Showing warnings for <@${member.user.id}>\nTotal warnings: ${activeWarnings.length}`);
+
+	userWarnings.forEach(warn => {
+		warningListEmbed.addFields({
+			name: `Warning ID: \`${warn.id}\``,
+			value: warn.reason + `\n---\nGiven on ${warn.timestamp} by <@${warn.admin_user_id}>`,
+		});
+	});
+
+	await interaction.followUp({ embeds: [warningListEmbed], ephemeral: true });
+}
+
+export async function removeWarnHandler(interaction: CommandInteraction, warnId: string): Promise<void> {
+	await interaction.deferReply({
+		ephemeral: true
+	});
+
+	const warning = await Warning.findOne({
+		where: {
+			id: Number(warnId),
+		}
+	});
+
+	if (!warning) {
+		await interaction.followUp({ content: 'Could not find warning', ephemeral: true });
+		return;
+	}
+
+	const [affectedUpdates] = await Warning.update({
+		expires_at: new Date(),
+	}, {
+		where: {
+			id: Number(warnId),
+		}
+	});
+	if (affectedUpdates < 1) {
+		await interaction.followUp({ content: 'Failed to remove warning', ephemeral: true });
+		return;
+	}
+
+	await interaction.followUp({ content: 'Successfully removed warning', ephemeral: true });
+}
+
+const command = new SlashCommandBuilder()
+	.setDefaultMemberPermissions('0')
+	.setName('manage-warn')
+	.setDescription('Manage warns for users')
+	.addSubcommand(subcommand => {
+		return subcommand.setName('view')
+			.setDescription('View warns of a user')
+			.addUserOption(option => {
+				return option.setName('user')
+					.setDescription('User view warns for')
+					.setRequired(true);
+			});
+	})
+	.addSubcommand(subcommand => {
+		return subcommand.setName('remove')
+			.setDescription('Remove a warning')
+			.addStringOption(option => {
+				return option.setName('id')
+					.setDescription('Warning to remove')
+					.setRequired(true);
+			});
+	});
+
+export default {
+	name: command.name,
+	handler: manageWarnCommandHandler,
+	deploy: command.toJSON()
+};

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -7,6 +7,7 @@ import { ordinal, sendEventLogMessage } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction, CommandInteraction, ModalSubmitInteraction } from 'discord.js';
+import { Op } from 'sequelize';
 
 async function warnCommandHandler(interaction: ChatInputCommandInteraction): Promise<void> {
 	const subcommand = interaction.options.getSubcommand();
@@ -82,7 +83,10 @@ export async function warnHandler(interaction: CommandInteraction | ModalSubmitI
 
 		const { count, rows } = await Warning.findAndCountAll({
 			where: {
-				user_id: member.id
+				user_id: member.id,
+				expires_at: {
+					[Op.lte]: new Date(),
+				}
 			}
 		});
 

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -8,6 +8,7 @@ import warnCommand from '@/commands/warn';
 import modpingCommand from '@/commands/modping';
 import messageLogContextMenu from '@/context-menus/messages/message-log';
 import slowModeCommand from '@/commands/slow-mode';
+import manageWarnCommand from '@/commands/manage-warn';
 import warnContextMenu from '@/context-menus/users/warn';
 import kickContextMenu from '@/context-menus/users/kick';
 import banContextMenu from '@/context-menus/users/ban';
@@ -56,6 +57,7 @@ function loadBotHandlersCollection(client: Client): void {
 	client.commands.set(warnCommand.name, warnCommand);
 	client.commands.set(modpingCommand.name, modpingCommand);
 	client.commands.set(slowModeCommand.name, slowModeCommand);
+	client.commands.set(manageWarnCommand.name, manageWarnCommand);
 
 	client.contextMenus.set(messageLogContextMenu.name, messageLogContextMenu);
 	client.contextMenus.set(warnContextMenu.name, warnContextMenu);

--- a/src/models/warnings.ts
+++ b/src/models/warnings.ts
@@ -8,6 +8,7 @@ export class Warning extends Model<InferAttributes<Warning>, InferCreationAttrib
 	declare admin_user_id: string;
 	declare reason: string;
 	declare timestamp: CreationOptional<Date>;
+	declare expires_at: CreationOptional<Date>;
 }
 
 Warning.init({
@@ -28,5 +29,8 @@ Warning.init({
 	timestamp: {
 		type: DataTypes.DATE,
 		defaultValue: DataTypes.NOW
-	}
+	},
+	expires_at: {
+		type: DataTypes.DATE,
+	},
 }, { sequelize, tableName: 'warnings' });


### PR DESCRIPTION
Does not resolve an approved issue, moderators have been asking for this feature for ages though.

### Changes:
- Added warn manage command: view warns for user + remove a warning
- Added expiry to warnings data model. set to in the past effectively remove a warning

This isn't a perfect solution, but right now there is no way to do it at all and it's needed right now.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.