### PR TITLE
Fix crashes in `messageUpdate` Discord event

### DIFF
--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -28,7 +28,7 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 		if (newMessage.channel instanceof BaseGuildTextChannel) {
 			channelName = newMessage.channel.name;
 		}
-	
+
 		const eventLogEmbed = new EmbedBuilder();
 
 		eventLogEmbed.setColor(0xC0C0C0);
@@ -41,7 +41,7 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 			},
 			{
 				name: 'User ID',
-				value: user.id
+				value: user.id || 'User ID not found'
 			},
 			{
 				name: 'Channel Tag',
@@ -49,16 +49,16 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 			},
 			{
 				name: 'Channel Name',
-				value: channelName
+				value: channelName || 'No channel name found'
 			},
 			{
 				name: 'Old Message',
-				value: oldMessageContent,
+				value: oldMessageContent || '***Missing Content***',
 				inline: true
 			},
 			{
 				name: 'New Message',
-				value: newMessageContent,
+				value: newMessageContent || '***Missing Content***',
 				inline: true
 			}
 		);
@@ -82,7 +82,7 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 					eventLogEmbed.addFields([
 						{
 							name: 'Previous audit event',
-							value: auditMessage.url
+							value: auditMessage.url || 'No URL found'
 						}
 					]);
 				}
@@ -94,7 +94,7 @@ export default async function messageUpdateHandler(oldMessage: Message | Partial
 			return;
 		}
 
-		await MessageAuditRelationship.create({ 
+		await MessageAuditRelationship.create({
 			message_id: newMessage.id,
 			log_event_id: audit.id
 		});


### PR DESCRIPTION
Resolves #XXX

### Changes:

Adds default values for the embed fields created by the `messageUpdate` event. This seems to be at least one cause of the crashes that happen at times in prod.

According to the crash logs, this is the latest error that crashed the bot:

```
node:events:502
      throw er; // Unhandled 'error' event
      ^
CombinedPropertyError: Received one or more errors
    at _ArrayValidator.handle (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:1254:70)
    at _ArrayValidator.parse (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:972:90)
    at EmbedBuilder.spliceFields (/home/node/app/node_modules/@discordjs/builders/dist/index.js:261:31)
    at EmbedBuilder.setFields (/home/node/app/node_modules/@discordjs/builders/dist/index.js:277:10)
    at Client.messageUpdateHandler (/home/node/app/dist/events/messageUpdate.js:30:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
Emitted 'error' event on Client instance at:
    at emitUnhandledRejectionOrErr (node:events:407:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:84:21) {
  errors: [
    [
      4,
      CombinedPropertyError: Received one or more errors
          at _ObjectValidator.handleIgnoreStrategy (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:2136:70)
          at _ObjectValidator.handleStrategy (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:1983:47)
          at _ObjectValidator.handle (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:2089:17)
          at _ObjectValidator.run (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:958:23)
          at _ArrayValidator.handle (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:1248:37)
          at _ArrayValidator.parse (/home/node/app/node_modules/@sapphire/shapeshift/dist/cjs/index.cjs:972:90)
          at EmbedBuilder.spliceFields (/home/node/app/node_modules/@discordjs/builders/dist/index.js:261:31)
          at EmbedBuilder.setFields (/home/node/app/node_modules/@discordjs/builders/dist/index.js:277:10)
          at Client.messageUpdateHandler (/home/node/app/dist/events/messageUpdate.js:30:23)
          at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
        errors: [ [ 'value', [ExpectedConstraintError] ] ]
      }
    ]
  ]
}
```

`messageUpdate.js:30` is this line https://github.com/PretendoNetwork/chubby/blob/db4c7148a1aed9bbd5f577bcf79393781d456c76/src/events/messageUpdate.ts#L37. It seems like the inputs are failing validation, but it's not saying WHY they're failing. The only thing I can think of is that one of the fields was empty, so I added defaults for all fields.

We *could* also just wrap everything in a `try-catch`, but that doesn't fix the underlying issue and would mean we still lose logs.

Marking as draft since this might not actually be the crash reason, and in case we want to use this PR to fix other related crashes when they come up?

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.