### PR TITLE
feat: anonymize moderation actions to the end-user

### DIFF
--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -104,10 +104,6 @@ export async function kickHandler(interaction: CommandInteraction | ModalSubmitI
 			banEmbed.setDescription('You have been banned from the Pretendo Network server. You may not rejoin at this time, and an appeal may not be possible\nYou may review the details of your ban below');
 			banEmbed.setColor(0xF24E43);
 			banEmbed.setTimestamp(Date.now());
-			banEmbed.setAuthor({
-				name: `Banned by: ${executor.tag}`,
-				iconURL: executor.avatarURL() ?? undefined
-			});
 			banEmbed.setFooter({
 				text: 'Pretendo Network',
 				iconURL: guild.iconURL()!

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -111,10 +111,6 @@ export async function warnHandler(interaction: CommandInteraction | ModalSubmitI
 			punishmentEmbed.setDescription('You have been kicked from the Pretendo Network server. You may rejoin after reviewing the details of the kick below');
 			punishmentEmbed.setColor(0xEF7F31);
 			punishmentEmbed.setTimestamp(Date.now());
-			punishmentEmbed.setAuthor({
-				name: `Kicked by: ${executor.tag}`,
-				iconURL: executor.avatarURL() ?? undefined
-			});
 			punishmentEmbed.setFooter({
 				text: 'Pretendo Network',
 				iconURL: guild.iconURL()!
@@ -143,10 +139,6 @@ export async function warnHandler(interaction: CommandInteraction | ModalSubmitI
 			punishmentEmbed.setDescription('You have been banned from the Pretendo Network server. You may not rejoin at this time, and an appeal may not be possible\nYou may review the details of your ban below');
 			punishmentEmbed.setColor(0xF24E43);
 			punishmentEmbed.setTimestamp(Date.now());
-			punishmentEmbed.setAuthor({
-				name: `Banned by: ${executor.tag}`,
-				iconURL: executor.avatarURL() ?? undefined
-			});
 			punishmentEmbed.setFooter({
 				text: 'Pretendo Network',
 				iconURL: guild.iconURL()!
@@ -180,7 +172,6 @@ export async function warnHandler(interaction: CommandInteraction | ModalSubmitI
 
 			for (let i = 0; i < rows.length; i++) {
 				const warning = rows[i];
-				const warningBy = await interaction.client.users.fetch(warning.admin_user_id);
 
 				pastWarningsEmbed.addFields(
 					{


### PR DESCRIPTION
### Changes:

- We are currently telling a kicked/banned user who the executor of that mod action was. I don't think I need to elaborate on why that's a bad idea.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.