### PR TITLE
Permission safeguards

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,7 +1,7 @@
 import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Ban } from '@/models/bans';
-import { banMessageDeleteChoices, sendEventLogMessage, isActionPermitted } from '@/util';
+import { banMessageDeleteChoices, sendEventLogMessage, canActOnUserList, createNoPermissionEmbed } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction, CommandInteraction, ModalSubmitInteraction, GuildMember } from 'discord.js';
@@ -37,33 +37,12 @@ export async function banHandler(interaction: CommandInteraction | ModalSubmitIn
 	bansListEmbed.setTitle('User Bans :thumbsdown:');
 	bansListEmbed.setColor(0xFFA500);
 
-	// user ids of people the executor can't act upon
-	const peerOrHigher: string[] = [];
+	const action = await canActOnUserList(interaction.member as GuildMember, userIDs);
 
-	// check that the executor has sufficient perms to act upon all the listed users, before running the command
-	for (const userID of userIDs) {
-		const member = await interaction.guild!.members.fetch(userID);
+	if (!action.permitted) {
+		const actionNotPermittedEmbed = await createNoPermissionEmbed(action);
 
-		const permitted = await isActionPermitted(interaction.member as GuildMember, member);
-
-		if (!permitted) {
-			peerOrHigher.push(userID);
-		}
-	}
-
-	if (peerOrHigher.length > 0) {
-		const commandFailedEmbed = new EmbedBuilder();
-		commandFailedEmbed.setTitle('Unable to run command');
-		commandFailedEmbed.setColor(0xFFA500);
-		commandFailedEmbed.setDescription(`${peerOrHigher.length} of the users you tried to act upon ha${peerOrHigher.length === 1 ? 's' : 've'} the same or a higher rank than you.\nThe command has **not** been run.`);
-		peerOrHigher.forEach((p) => {
-			commandFailedEmbed.addFields({
-				name: `ID: \`${p}\``,
-				value: `<@${p}>`
-			});
-		});
-
-		await interaction.followUp({ embeds: [commandFailedEmbed], ephemeral: true });
+		await interaction.followUp({ embeds: [actionNotPermittedEmbed], ephemeral: true });
 
 		return;
 	}

--- a/src/commands/kick.ts
+++ b/src/commands/kick.ts
@@ -2,7 +2,7 @@ import { EmbedBuilder } from 'discord.js';
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { Kick } from '@/models/kicks';
 import { Ban } from '@/models/bans';
-import { banMessageDeleteChoices, sendEventLogMessage, isActionPermitted } from '@/util';
+import { banMessageDeleteChoices, sendEventLogMessage, canActOnUserList, createNoPermissionEmbed } from '@/util';
 import { untrustUser } from '@/leveling';
 import { notifyUser } from '@/notifications';
 import type { ChatInputCommandInteraction, CommandInteraction, ModalSubmitInteraction, GuildMember } from 'discord.js';
@@ -38,33 +38,12 @@ export async function kickHandler(interaction: CommandInteraction | ModalSubmitI
 	kicksListEmbed.setTitle('User Kicks :thumbsdown:');
 	kicksListEmbed.setColor(0xFFA500);
 
-	// user ids of people the executor can't act upon
-	const peerOrHigher: string[] = [];
+	const action = await canActOnUserList(interaction.member as GuildMember, userIDs);
 
-	// check that the executor has sufficient perms to act upon all the listed users, before running the command
-	for (const userID of userIDs) {
-		const member = await interaction.guild!.members.fetch(userID);
+	if (!action.permitted) {
+		const actionNotPermittedEmbed = await createNoPermissionEmbed(action);
 
-		const permitted = await isActionPermitted(interaction.member as GuildMember, member);
-
-		if (!permitted) {
-			peerOrHigher.push(userID);
-		}
-	}
-
-	if (peerOrHigher.length > 0) {
-		const commandFailedEmbed = new EmbedBuilder();
-		commandFailedEmbed.setTitle('Unable to run command');
-		commandFailedEmbed.setColor(0xFFA500);
-		commandFailedEmbed.setDescription(`${peerOrHigher.length} of the users you tried to act upon ha${peerOrHigher.length === 1 ? 's' : 've'} the same or a higher rank than you.\nThe command has **not** been run.`);
-		peerOrHigher.forEach((p) => {
-			commandFailedEmbed.addFields({
-				name: `ID: \`${p}\``,
-				value: `<@${p}>`
-			});
-		});
-
-		await interaction.followUp({ embeds: [commandFailedEmbed], ephemeral: true });
+		await interaction.followUp({ embeds: [actionNotPermittedEmbed], ephemeral: true });
 
 		return;
 	}


### PR DESCRIPTION
### Changes:
- If a user tries to warn/kick/ban someone with a role of the same/higher rank as them, the command doesn't run and displays this message:
<img width="544" height="230" alt="Screenshot_20260115_042546" src="https://github.com/user-attachments/assets/a121975b-e4de-469d-a6c8-94c118106853" />

- Fixed an issue where multiuser commands didn't parse new ids correctly (user IDs can now be 19 characters long).

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.